### PR TITLE
Re-organize and restructure standards matching

### DIFF
--- a/match-standards-mix01.Rmd
+++ b/match-standards-mix01.Rmd
@@ -18,19 +18,22 @@ library(BiocParallel)
 library(Spectra)
 library(RColorBrewer)
 library(MetaboAnnotation)
+library(pheatmap)
+setMSnbaseFastLoad(FALSE)
 ```
 
 ```{r general-settings, echo = FALSE}
 mix <- 1
 mix_name <- paste0("Mix", ifelse(mix < 10, paste0(0, mix), mix)) 
 IMAGE_PATH <- paste0("images/match-standards-", tolower(mix_name),"/")
+if (dir.exists(IMAGE_PATH)) unlink(IMAGE_PATH, recursive = TRUE)
 RDATA_PATH <- paste0("data/RData/match-standards-/", tolower(mix_name), "/")
 dir.create(IMAGE_PATH, showWarnings = FALSE, recursive = TRUE)
 dir.create(RDATA_PATH, showWarnings = FALSE, recursive = TRUE)
 
 # Define the mzML files *base* path (/data/massspec/mzML/ on the cluster)
 MZML_PATH <- "~/mix01/"
-# MZML_PATH <- "/data/massspec/mzML/"
+MZML_PATH <- "/data/massspec/mzML/"
 
 # Set up parallel processing using 2 cores
 if (.Platform$OS.type == "unix") {
@@ -182,7 +185,7 @@ times for the standards is shown below.
 bpc <- chromatogram(data_WP, aggregationFun = "max", msLevel = 1L,
                     mz = c(60, 900), include = "none")
 par(mfrow = c(2, 1), mar = c(0, 20, 1.5, 0.5))
-plot(bpc, peakType = "none", col = paste0(col_group[bpc$group], 80))
+plot(bpc, col = paste0(col_group[bpc$group], 80))
 legend("topright", col = col_group, lty = 1, legend = names(col_group))
 abline(v = std_dilution01$RT, lty = 2)
 par(mar = c(4.5, 20, 0, 0.5))
@@ -194,11 +197,11 @@ There is a clear difference in the signal of samples with high and low
 concentration of the standards.
 
 
-### Differnce in concentration (between high and low concentration samples)
+### Signal intensity difference
 
-We compute the t.test statistic and the related p-value for the difference in
-log2 concentration (between high and low concentration samples) for each of the
-identified features.
+We compute the difference in (log2) signals between samples with high and low
+concentration of the standards and calculate the p-value for this difference
+using the Student's t-test.
 
 ```{r}
 fVlog2 <- log2(featureValues(data_WP, value = "into",
@@ -279,21 +282,23 @@ case.
 ### Standards with matching features
 
 While for some standards a matching feature was found we still need to evaluate
-whether this matching makes sense. For each standard we thus first evaluate the
+whether this matching is correct. For each standard we thus first evaluate the
 EICs for all matching features, then we match their MS2 spectra (if available)
-against reference libraries.
+against reference libraries. To ensure correct assignment of a feature, its
+retention time and eventually related MS2 spectra, we require the following
+to be true:
 
-Annotation criteria:
-
-- 1: feature(s) was/were found with m/z matching those of adduct(s) of the
+- feature(s) was/were found with m/z matching those of adduct(s) of the 
   standard.
-- 2: signal is higher for samples with higher concentration.
-- 3: MS2 spectra matches reference library.
+- signal is higher for samples with higher concentration.
+- MS2 spectra matches reference spectra for the standard (if available).
+- MS2 spectra don't match MS2 spectra of other compounds.
 
 We next load the reference libraries we will use for the MS2 matching. These are
 HMDB and MassBank.
 
 ```{r}
+register(SerialParam())
 library(CompoundDb)
 
 cdb <- CompDb("data/CompDb.Hsapiens.HMDB.5.0.sqlite")
@@ -323,24 +328,27 @@ ions from two different compounds.
 We next plot the EIC for the assigned feature and visually inspect these.
 
 ```{r, echo = FALSE}
-eics <- featureChromatograms(data_WP, features = rownames(tmp))
-dr <- file.path(IMAGE_PATH, std)
-dir.create(dr, showWarnings = FALSE)
-col_sample <- col_group[eics$group]
+plot_eics <- function(x, std, tab) {
+    eics <- featureChromatograms(x, features = rownames(tab))
+    dr <- file.path(IMAGE_PATH, std)
+    dir.create(dr, showWarnings = FALSE)
+    col_sample <- col_group[eics$group]
 
-for (i in seq_len(nrow(eics))) {
-    ft <- rownames(tmp)[i]
-    fl <- file.path(dr, paste0("WP_", ft, ".png"))
-    png(fl, width = 12, height = 8, units = "cm", res = 300, pointsize = 6)
-    eic <- eics[i, ]
-    plot(eic, col = paste0(col_sample, 80),
-         peakBg = paste0(col_sample[chromPeaks(eic)[, "sample"]], 40))
-    abline(v = tmp$target_RT[1], lty = 2, col = "#00000060")
-    grid()
-    legend("topleft", c(std, tmp$adduct[i], ft))
-    legend("topright", col = col_group, legend = names(col_group), lty = 1)
-    dev.off()
+    for (i in seq_len(nrow(eics))) {
+        ft <- rownames(tab)[i]
+        fl <- file.path(dr, paste0("WP_", ft, ".png"))
+        png(fl, width = 12, height = 8, units = "cm", res = 300, pointsize = 6)
+        eic <- eics[i, ]
+        plot(eic, col = paste0(col_sample, 80),
+             peakBg = paste0(col_sample[chromPeaks(eic)[, "sample"]], 40))
+        abline(v = tab$target_RT[1], lty = 2, col = "#00000060")
+        grid()
+        legend("topleft", c(std, tab$adduct[i], ft))
+        legend("topright", col = col_group, legend = names(col_group), lty = 1)
+        dev.off()
+    }
 }
+plot_eics(data_WP, std, tmp)
 ```
 
 The EICs for the feature with the higher intensity for each of the two potential
@@ -372,7 +380,11 @@ extract_ms2 <- function(x, features) {
                           features = features)
     res <- filterIntensity(res, intensity = low_int)
     res <- res[lengths(res) > 1]
-    addProcessing(res, scale_int)
+    if (!length(res))
+        return(res)
+    res <- addProcessing(res, scale_int)
+    spectraNames(res) <- paste0(res$feature_id, "_", spectraNames(res))
+    res
 }
 
 std_ms2 <- extract_ms2(data_WP, rownames(tmp))
@@ -388,8 +400,48 @@ The MS2 spectra look rather busy with a large number of peaks. The first two
 belong to the first set of features with a retention time of about 250, the 3rd
 one to the second set of features with a retention time of ~ 200.
 
-Next we match the MS2 spectra against all reference spectra from HMDB and
-identify spectra with a similarity higher than 0.7.
+We next match the extracted MS2 spectra against the reference spectra for 
+`r std` from HMDB.
+
+```{r mix01-water-3-phosphoglyceric-acid-ms2-hmdb-heatmap, fig.path = IMAGE_PATH, fig.cap = "Similarities of MS2 spectra for selected features against reference spectra for 3-Phoshoglyceric Acid from HMDB."}
+hmdb_id <- std_dilution$HMDB.code[std_dilution$name == std]
+hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+
+sim <- compareSpectra(std_ms2, hmdb, ppm = 40)
+
+ann <- data.frame(feature_id = std_ms2$feature_id, rt = rtime(std_ms2))
+rownames(ann) <- rownames(sim)
+
+pheatmap(sim, annotation_row = ann, breaks = seq(0, 1, length.out = 101),
+         color = colorRampPalette((brewer.pal(n = 7, name = "YlOrRd")))(100))
+```
+
+The MS2 spectra for FT1539 match those of 3-Phosphoglyceric Acid, albeit with a
+low similarity score while the MS2 spectrum for FT1793 does not match the
+reference spectra.
+
+The first two spectra match MS2 spectra for `r std` from HMDB with a similarity
+of about 0.4. These are shown in the mirror plots below.
+
+```{r mix01-water-3-phosphoglyceric-acid-mirror-hmdb, echo = FALSE, fig.cap = "Mirror plots"}
+idx <- which(sim > 0.3, arr.ind = TRUE)
+
+par(mfrow = c(floor(sqrt(nrow(idx))), ceiling(sqrt(nrow(idx)))))
+for (i in seq_len(nrow(idx))) {
+    a <- idx[i, 1L]
+    b <- idx[i, 2L]
+    plotSpectraMirror(std_ms2[a], addProcessing(hmdb[b], scale_int),
+                      main = paste(std_ms2$feature_id[a], hmdb$name[b]))
+}
+```
+
+Although not perfect, it seems that feature FT1539 contains signal from an ion
+of `r std`.
+
+In addition we match the MS2 spectra for the matched features against all
+spectra from HMDB identifying reference spectra with a similarity larger than
+0.7. This is to ensure that no reference spectra from any other compound would
+match the extracted spectra for this feature with a higher similarity.
 
 ```{r}
 hmdb_match <- matchSpectra(
@@ -410,31 +462,6 @@ mbank_match
 
 Also for MassBank no match was found.
 
-As an alternative, we calculate also pairwise differences of the 3 experimental
-spectra against the MS2 spectra for `r std` from HMDB.
-
-```{r}
-hmdb_id <- std_dilution$HMDB.code[std_dilution$name == std]
-hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
-
-sim <- compareSpectra(std_ms2, hmdb, ppm = 40)
-sim
-```
-
-The first two spectra match MS2 spectra for `r std` from HMDB with a similarity
-of about 0.4. These are shown in the mirror plots below.
-
-```{r mix01-water-3-phosphoglyceric-acid-mirror-hmdb, echo = FALSE, fig.cap = "Mirror plots"}
-par(mfrow = c(2, 2))
-plotSpectraMirror(std_ms2[1L], hmdb[8L], ppm = 40)
-plotSpectraMirror(std_ms2[1L], hmdb[14L], ppm = 40)
-plotSpectraMirror(std_ms2[2L], hmdb[8L], ppm = 40)
-plotSpectraMirror(std_ms2[2L], hmdb[14L], ppm = 40)
-```
-
-Although not perfect, it seems that feature 
-`r paste0(unique(std_ms2[1:2]$feature_id), collapse = ", ")` contains signal for
-an ion from `r std`.
 
 
 #### Acetylhistidine
@@ -460,24 +487,7 @@ from 4 different compounds.
 We next plot the EIC for the assigned feature and visually inspect these.
 
 ```{r, echo = FALSE}
-eics <- featureChromatograms(data_WP, features = rownames(tmp))
-dr <- file.path(IMAGE_PATH, std)
-dir.create(dr, showWarnings = FALSE)
-col_sample <- col_group[eics$group]
-
-for (i in seq_len(nrow(eics))) {
-    ft <- rownames(tmp)[i]
-    fl <- file.path(dr, paste0("WP_", ft, ".png"))
-    png(fl, width = 12, height = 8, units = "cm", res = 300, pointsize = 6)
-    eic <- eics[i, ]
-    plot(eic, col = paste0(col_sample, 80),
-         peakBg = paste0(col_sample[chromPeaks(eic)[, "sample"]], 40))
-    abline(v = tmp$target_RT[1], lty = 2, col = "#00000060")
-    grid()
-    legend("topleft", c(std, tmp$adduct[i], ft))
-    legend("topright", col = col_group, legend = names(col_group), lty = 1)
-    dev.off()
-}
+plot_eics(data_WP, std, tmp)
 ```
 
 Again, we show a representative EIC for each *feature group* (ordered by
@@ -520,7 +530,20 @@ pheatmap(sim, annotation_row = ann, breaks = seq(0, 1, length.out = 101),
 ```
 
 The MS2 spectra for FT1643 have the highest similarity against MS2 spectra from
-`r std`.
+`r std`. Mirror plots for the best matching spectra are shown below.
+
+```{r mix01-water-acetylhistidine-mirror-hmdb, echo = FALSE, fig.cap = "Mirror plots"}
+idx <- which(sim > 0.6, arr.ind = TRUE)
+
+par(mfrow = c(floor(sqrt(nrow(idx))), ceiling(sqrt(nrow(idx)))))
+for (i in seq_len(nrow(idx))) {
+    a <- idx[i, 1L]
+    b <- idx[i, 2L]
+    plotSpectraMirror(std_ms2[a], addProcessing(hmdb[b], scale_int),
+                      main = paste(std_ms2$feature_id[a], hmdb$name[b]))
+}
+```
+
 
 In addition we match the MS2 spectra for the matched features against all
 spectra from HMDB.
@@ -545,12 +568,162 @@ for that compound, even if their MS2 spectra match also reference spectra from
 other compounds.
 
 
+#### Betaine
+
+```{r, echo = FALSE}
+std <- "Betaine"
+```
+
+The table below lists all features that were matched to one of the adducts of 
+`r print(std)` that have in addition also on average a twice as high signal in
+samples with higher concentrations than in those with lower concentrations.
+
+```{r, results = "asis", echo = FALSE}
+tmp <- as.data.frame(mD[mD$target_name == std, ])
+tmp <- tmp[order(tmp$rtmed), ]
+pandoc.table(tmp, style = "rmarkdown",
+             split.tables = Inf, caption = "Feature to standards matches.")
+```
+
+Based on their retention time, it seems that these features represent signal
+from several different compounds.
+
+We next plot the EIC for the assigned feature and visually inspect these.
+
+```{r, echo = FALSE}
+plot_eics(data_WP, std, tab = tmp)
+```
+
+Again, we show a representative EIC for each *feature group*.
+
+![](images/match-standards-mix01/Betaine/WP_FT0544.png)
+
+![](images/match-standards-mix01/Betaine/WP_FT0878.png)
+
+![](images/match-standards-mix01/Betaine/WP_FT0883.png)
+
+The signal from the first feature above looks OK while the others are rather
+noisy.
+
+We next extract the MS2 spectra for all these features and match them against
+the reference spectra for `r std` from HMDB.
+
+```{r mix01-water-betaine-ms2, fig.path = IMAGE_PATH, fig.cap = "MS2 spectra for features matched to betaine.", echo = FALSE}
+std_ms2 <- extract_ms2(data_WP, rownames(tmp))
+
+plotSpectra(std_ms2)
+```
+
+We have thus only MS2 spectra for features with a retention time around 160 or
+180 seconds. Next we compare them against the reference spectra for `r std` from
+HMDB. The results are shown in the heatmap below.
+
+```{r mix01-water-betaine-ms2-hmdb-heatmap, fig.path = IMAGE_PATH, fig.cap = "Similarities of MS2 spectra for selected features against reference spectra for Betaine from HMDB."}
+hmdb_id <- std_dilution$HMDB.code[std_dilution$name == std]
+hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+
+sim <- compareSpectra(std_ms2, hmdb, ppm = 40)
+
+ann <- data.frame(feature_id = std_ms2$feature_id, rt = rtime(std_ms2))
+rownames(ann) <- rownames(sim)
+
+library(pheatmap)
+pheatmap(sim, annotation_row = ann, breaks = seq(0, 1, length.out = 101),
+         color = colorRampPalette((brewer.pal(n = 7, name = "YlOrRd")))(100))
+```
+
+Only the MS2 spectra for FT0544 (with a retention time of 162 match the
+reference spectra from betaine.
+
+```{r mix01-water-betaine-mirror-hmdb, echo = FALSE, fig.cap = "Mirror plots"}
+idx <- which(sim > 0.6, arr.ind = TRUE)
+
+par(mfrow = c(floor(sqrt(nrow(idx))), ceiling(sqrt(nrow(idx)))))
+for (i in seq_len(nrow(idx))) {
+    a <- idx[i, 1L]
+    b <- idx[i, 2L]
+    plotSpectraMirror(std_ms2[a], addProcessing(hmdb[b], scale_int),
+                      main = paste(std_ms2$feature_id[a], hmdb$name[b]))
+}
+```
+
+In addition we match the MS2 spectra for the matched features against all
+spectra from HMDB.
+
+```{r}
+hmdb_match <- matchSpectra(
+    std_ms2, Spectra(cdb),
+    param = CompareSpectraParam(ppm = 50, requirePrecursor = FALSE))
+hmdb_match
+```
+
+```{r}
+hmdb_match <- hmdb_match[whichQuery(hmdb_match)]
+
+tab <- spectraData(hmdb_match, c("feature_id", "rtime", "target_name", "score"))
+pandoc.table(as.data.frame(tab), style = "rmarkdown", split.table = Inf)
+```
+
+Thus, the MS2 spectra for feature FT0544 clearly match Betaine.
+
+
+#### C3 Carnitine
+
+```{r, echo = FALSE}
+std <- "C3 Carnitine"
+```
+
+The table below lists all features that were matched to one of the adducts of 
+`r print(std)` that have in addition also on average a twice as high signal in
+samples with higher concentrations than in those with lower concentrations.
+
+```{r, results = "asis", echo = FALSE}
+tmp <- as.data.frame(mD[mD$target_name == std, ])
+tmp <- tmp[order(tmp$rtmed), ]
+pandoc.table(tmp, style = "rmarkdown",
+             split.tables = Inf, caption = "Feature to standards matches.")
+```
+
+Based on their retention time, it seems that these features represent signal
+from two different compounds.
+
+We next plot the EIC for the assigned feature and visually inspect these.
+
+```{r, echo = FALSE}
+plot_eics(data_WP, std, tab = tmp)
+```
+
+Again, we show a representative EIC for each *feature group*.
+
+![](images/match-standards-mix01/C3 Carnitine/WP_FT1691.png)
+
+![](images/match-standards-mix01/C3 Carnitine/WP_FT1886.png)
+
+![](images/match-standards-mix01/C3 Carnitine/WP_FT2112.png)
+
+We next extract the MS2 spectra for all these features and match them against
+the reference spectra for `r std` from HMDB.
+
+```{r mix01-water-c3-carnitine-ms2, fig.path = IMAGE_PATH, fig.cap = "MS2 spectra for features matched to C3 Carnitine.", echo = FALSE}
+std_ms2 <- extract_ms2(data_WP, rownames(tmp))
+if (length(std_ms2)) {
+    plotSpectra(std_ms2)
+} else {
+    plot(3, 3, pch = NA, xaxt = "n", yaxt = "n")
+    text(3, 3, labels = "No Spectra")
+}
+```
+
+Unfortunately we don't have any MS2 spectra available.
+
+
+
 
 
 ### Standards without any matching feature
 
 
-## Alternative
+## Alternative?
 
 Sort of a reverse approach. Instead of starting with MS1 we start with MS2.
 
@@ -561,90 +734,6 @@ Sort of a reverse approach. Instead of starting with MS1 we start with MS2.
 - If features also exhibit a difference between concentrations AND the m/z
   matches those of an adduct of the standard -> Bingo.
 
-### A subsection for each of these standards to investigate why no match was found for them?
-
-### Plot features EICs
-
-We plot the EICs of the features that were matched to standards
-```{r}
-dr <- paste0(IMAGE_PATH, "eic_features_WP")
-dir.create(dr, showWarnings = FALSE, recursive = TRUE)
-for (ft in rownames(mD)) {
-  eics <- featureChromatograms(data_WP, features = ft, expandRt = 2, filled = TRUE)
-  png(paste0(IMAGE_PATH, "eic_features_WP/", ft, ".png"),
-      width = 10, height = 8, units = "cm", res = 300, pointsize = 6)
-  plotChromatogramsOverlay(eics) #or normalize(eics)
-  dev.off()
-}
-```
-
-### Annotating features using MS2 data
-
-Next we extract for all matched features potentially measured MS2 spectra
-and match them against MassBank in order to annotate them. We first extract 
-spectra from MassBank database.
-
-```{r}
-library(RMariaDB)
-library(MsBackendMassbank)
-
-co <- dbConnect(MariaDB(), user = "avwork", dbname = "MassBank",
-                 host = "localhost", pass = "massbank")
-mbank <- Spectra(co, source = MsBackendMassbankSql())
-mbank <- setBackend(mbank, MsBackendDataFrame()) # breaks with parallel processing
-```
-
-```{r}
-data_WP_ms2<- filterFile(data_WP, file = which(data_WP$mode != "FS"), keepFeatures = TRUE)
-```
-
-The following function (to avoid code repetition) takes the ids of
-features `f_id`, checks which ones are also available for the given MS2 data
-`data_ms2`. For these it extracts the corresponding spectra and matches them
-against a reference database `mbank`. It returns a vector. Each entry contains
-for a given feature the compound names of the spectra in `mbank` that were
-matched to the spectra of the feature.
-
-```{r}
-f_ms2_mtch <- function(data_ms2, f_id, mbank, case, recompute = FALSE) {
-  ids <- intersect(rownames(featureDefinitions(data_ms2)), f_id)
-  f_ms2 <- featureSpectra(data_ms2, msLevel = 2L, return.type = "Spectra",
-                          ppm = 10, features = ids)
-  fn <- paste0(RDATA_PATH, "comp_", case, "_ms2_MassBank.RData")
-  if(!file.exists(fn) | recompute) {
-    mtches <- matchSpectra(f_ms2, mbank,
-                           param = CompareSpectraParam(requirePrecursor = FALSE,
-                                                       ppm = 10))
-    save(mtches, file = fn)
-  }
-  else load(fn)
-  mtches <- mtches[whichQuery(mtches)]
-  tmp <- aggregate(mtches$target_compound_name,
-                   by = list(feature = mtches$feature_id),
-                   function(x) paste0(unique(x), collapse = ";"))
-  #tmp[tmp[, 2] == ""] <- NA
-  res <- rep(NA, length(f_id))
-  res[match(tmp[, 1], f_id)] <- tmp[, 2]
-  res
-}
-```
-
-
-```{r}
-mD$ms2_matches <- f_ms2_mtch(data_WP_ms2, rownames(mD), mbank, "WP")
-```
-
-# Final result
-
-```{r, results = "asis"}
-pandoc.table(as.data.frame(mD), style = "rmarkdown", split.tables = Inf,
-             caption = "Feature to standards and massbank matches")
-```
-
-Only a few features were matched to spectra of MassBank compounds and they not
-confirm feature to standard matches except the case of feature FT0158 that
-has been matched to Betaine and adduct [M+H]+ and also the associated MS2 data
-was matched to Betaine in MassBank.
 
 # Session information
 

--- a/match-standards-mix01.Rmd
+++ b/match-standards-mix01.Rmd
@@ -15,6 +15,9 @@ library(pander)
 library(MetaboCoreUtils)
 library(MetaboAnnotation)
 library(BiocParallel)
+library(Spectra)
+library(RColorBrewer)
+library(MetaboAnnotation)
 ```
 
 ```{r general-settings, echo = FALSE}
@@ -42,12 +45,14 @@ if (.Platform$OS.type == "unix") {
 Mixes of standards have been solved in water or added to human serum sample
 pools in two different concentration and these samples were measured with the
 LC-MS setup from Eurac (used also to generate the CHRIS untargeted metabolomics
-data). The goal of this analysis is now to:
+data). The goal of this analysis is to create an in-house reference library for
+our untargeted LC-MS setup. For that we:
 
-- Determine the retention time of each standard in water and serum.
-- Define which ions/adducts are measured for each standard (with relative
+- determine the retention time of each standard in water and serum.
+- define which ions/adducts are measured for each standard (with relative
   abundances, i.e. which is most highly abundant ion etc).
-- Extract all MS/MS spectra for each standard and store that in a database.
+- extract all MS/MS spectra for each standard, match them against reference
+  spectra and store them in a database.
 
 # Identifying standards in sample mix 01
 
@@ -57,14 +62,14 @@ formula) and subset to those from mix01.
 ```{r, echo = FALSE, results = "asis"}
 std_dilution <- read.table("data/standards_dilution.txt",
                            sep = "\t", header = TRUE)
-std_dilution$exactmass <- vapply(std_dilution$formula, 
-                                  function(z) calculateMass(z), numeric(1))
+std_dilution$exactmass <- calculateMass(std_dilution$formula)
 std_dilution01 <- std_dilution[std_dilution$mix == mix, ]
 ```
 
 The list of standards that constitute the present sample mix are listed below
 along with the expected retention time and the most abundant adduct for positive
-and negative polarity as defined in a previous analysis.
+and negative polarity as defined manually in a previous analysis by Mar
+Garcia-Aloy.
 
 ```{r, echo = FALSE, results = "asis"}
 pandoc.table(std_dilution01[, c("name", "formula", "RT", "POS", "NEG")], 
@@ -78,10 +83,25 @@ We load the data and split it according to matrix and polarity.
 
 ```{r}
 std_files <- read.table("data/std_serum_files.txt", header = TRUE)
+std_files$concentration <- "blank"
+std_files$concentration[grep("High", std_files$class)] <- "high"
+std_files$concentration[grep("Low", std_files$class)] <- "low"
+std_files$group <- std_files$concentration
+std_files$group[grep("CE", std_files$mode)] <- "MSMS"
+
+#' Define colors
+col_group <- brewer.pal(9, "Set1")[c(1, 5, 4, 9)]
+names(col_group) <- c("high", "low", "MSMS", "blank")
+
+#' Subset and load data.
 std_files <- std_files[which(std_files$type == mix_name), ]
 fls <- paste0(MZML_PATH, std_files$folder, "/", std_files$mzML)
 data <- readMSData(fls, pdata = new("NAnnotatedDataFrame", std_files),
                    mode = "onDisk")
+data <- filterRt(data, rt = c(0, 350))
+data <- filterEmptySpectra(data)
+
+col_group <- col_group[unique(data$group)]
 ```
 
 ```{r}
@@ -97,13 +117,30 @@ data_SP <- filterFile(data, file = which(data$matrix_pol == "Serum_POS"))
 data_SN <- filterFile(data, file = which(data$matrix_pol == "Serum_NEG"))
 ```
 
-## Positive polarity and solved in water samples
+## Water, positive polarity
 
-### Chromatographic peak detection
+We first perform the analysis on the samples with the standards solved in pure
+water acquired in positive polarity mode.
+
+### Data pre-processing
+
+We perform the pre-processing of our data set which consists of the
+chromatographic peak detection followed by a peak refinement step to reduce peak
+detection artifacts, the correspondence analysis to group peaks across samples
+and finally the gap-filling to fill in missing peak data from samples in which
+no chromatographic peak was detected.
+
+Some notes on the settings for the pre-processing:
+
+- The `bw` parameter for the correspondence is larger than usual because adding
+  the standards in higher concentrations caused considerable retention time
+  shifts for some.
+- The `binSize` was also slightly increased to avoid splitting of features.
 
 ```{r peakdetection, eval = !file.exists(paste0(RDATA_PATH, "processed_data.RData"))}
+## Peak detection
 cwp <- CentWaveParam(ppm = 50,
-                     peakwidth = c(2, 20),
+                     peakwidth = c(2, 18),
                      snthresh = 5,
                      mzdiff = 0.001,
                      prefilter = c(4, 300),
@@ -111,41 +148,51 @@ cwp <- CentWaveParam(ppm = 50,
                      integrate = 2)
 
 data_WP <- findChromPeaks(data_WP, param = cwp) 
-```
 
-### Refinement
-
-```{r refinement, message = FALSE, warning = FALSE, eval = !file.exists(paste0(RDATA_PATH, "processed_data.RData"))}
-mnp <- MergeNeighboringPeaksParam(expandRt = 2.5, expandMz = 0.001,
+## Peak refinement
+mnp <- MergeNeighboringPeaksParam(expandRt = 3.5, expandMz = 0.001,
                                   minProp = 3/4)
 data_WP <- refineChromPeaks(data_WP, param = mnp)
-```
 
-### Correspondence analysis
+## Alignment
+pdp1 <- PeakDensityParam(sampleGroups = data_WP$matrix_pol, bw = 3,
+                        minFraction = 0.7, binSize = 0.015)
+data_WP <- groupChromPeaks(data_WP, param = pdp1)
+pgp <- PeakGroupsParam(minFraction = 0.8, extraPeaks = 100, span = 0.8)
+data_WP <- adjustRtime(data_WP, param = pgp)
 
-Next we perform a correspondence analysis to group chromatographic peaks across
-samples.
+## Correspondence analysis
+pdp2 <- PeakDensityParam(sampleGroups = data_WP$mode, bw = 3,
+                        minFraction = 0.3, binSize = 0.015)
+data_WP <- groupChromPeaks(data_WP, param = pdp2)
 
-```{r correspondence, echo = FALSE, eval = !file.exists(paste0(RDATA_PATH, "processed_data.RData"))}
-pdp <- PeakDensityParam(sampleGroups = data_WP$matrix_pol, bw = 1.8,
-                        minFraction = 0.7, binSize = 0.02)
-data_WP <- groupChromPeaks(data_WP, param = pdp)
-```
-
-### Gap filling
-
-Finally we fill-in missing peak data.
-
-```{r gap-filling, echo = FALSE, eval = !file.exists(paste0(RDATA_PATH, "processed_data.RData"))}
 ## Gap-filling
 data_WP <- fillChromPeaks(data_WP, param = ChromPeakAreaParam())
 save(data_WP, file = paste0(RDATA_PATH, "processed_data.RData"))
 ```
 
-
 ```{r correspondence-cached, echo = FALSE, eval = file.exists(paste0(RDATA_PATH, "processed_data.RData"))}
 load(paste0(RDATA_PATH, "processed_data.RData"))
 ```
+
+The base peak chromatogram and peak density image with the expected retention
+times for the standards is shown below.
+
+```{r mix01-water-pos-bpc, fig.path = IMAGE_PATH, echo = FALSE, caption = "Base peak chromatogram and chromatographic peak density image. Dashed vertical lines represent the expected retention times for the standards as defined in a previous manual analysis.", fig.width = 10, fig.height = 7}
+bpc <- chromatogram(data_WP, aggregationFun = "max", msLevel = 1L,
+                    mz = c(60, 900), include = "none")
+par(mfrow = c(2, 1), mar = c(0, 20, 1.5, 0.5))
+plot(bpc, peakType = "none", col = paste0(col_group[bpc$group], 80))
+legend("topright", col = col_group, lty = 1, legend = names(col_group))
+abline(v = std_dilution01$RT, lty = 2)
+par(mar = c(4.5, 20, 0, 0.5))
+plotChromPeakImage(data_WP, binSize = 3)
+abline(v = std_dilution01$RT, lty = 2)
+```
+
+There is a clear difference in the signal of samples with high and low
+concentration of the standards.
+
 
 ### Differnce in concentration (between high and low concentration samples)
 
@@ -154,23 +201,31 @@ log2 concentration (between high and low concentration samples) for each of the
 identified features.
 
 ```{r}
-fVlog2 <- log2(featureValues(data_WP, value = "into", method = "sum", filled = TRUE))
+fVlog2 <- log2(featureValues(data_WP, value = "into",
+                             method = "sum", filled = TRUE))
 high <- grep("High", colnames(fVlog2))
+high <- high[-grep("CE", colnames(fVlog2)[high])]
 low <- grep("Low", colnames(fVlog2))
 
 ttest <- t(apply(fVlog2, 1, function(x) {
-  res <- t.test(x[high], x[low], mu = 0)
-  c(high_low_diff = unname(res$estimate[1] - res$estimate[2]),
-    pvalue = res$p.value)
+    a <- x[high]
+    b <- x[low]
+    if (sum(!is.na(a)) > 1 && sum(!is.na(b)) > 1) {
+        res <- t.test(a, b, mu = 0)
+        c(high_low_diff = unname(res$estimate[1] - res$estimate[2]),
+          pvalue = res$p.value)
+    } else c(high_low_diff = mean(a, na.rm = TRUE) - mean(b, na.rm = TRUE),
+             pvalue = NA_real_)
 }))
 ```
+
 
 ### Identification of features matching standards
 
 We now identify all features matching likely adducts of the standards.
 
 ```{r}
-adducts <- c("[M+H]+", "[M+2H]2+", "[M+Na]+", "[M+K]+", "[M+NH4]+",
+adducts <- c("[M]+", "[M+H]+", "[M+2H]2+", "[M+Na]+", "[M+K]+", "[M+NH4]+",
              "[M+H-H2O]+", "[M+H+Na]2+", "[M+2Na]2+", "[M+H-NH3]+")
 prm <- Mass2MzParam(adducts = adducts, ppm = 30)
 fmat <- c(featureDefinitions(data_WP), ttest)
@@ -178,27 +233,333 @@ mtchs <- matchMz(fmat, std_dilution01, param =  prm, mzColname = "mzmed")
 mtchs_sub <- mtchs[whichQuery(mtchs)]
 ```
 
+We further reduce to features that show an at least twice as high signal
+in samples with the high concentration compared to the one with the low
+concentration. Note that we also keep features for which no difference was
+calculated (e.g. because in low concentration no signal was measured).
 
-```{r, results = "asis"}
-mD <- matchedData(mtchs_sub, columns = c("mzmed", "rtmed", "target_name",
-                                         "adduct", "score", "target_RT",
-                                         "target_POS", "high_low_diff",
-                                         "pvalue"))
+```{r, results = "asis", echo = FALSE}
+mD <- matchedData(mtchs_sub, columns = c("mzmed", "ppm_error", "rtmed",
+                                         "target_RT", "target_name",
+                                         "adduct", "target_POS",
+                                         "high_low_diff", "pvalue"))
+mD <- mD[-which(mD$high_low_diff < 1), ]
 mD <- mD[order(mD$target_name), ]
 pandoc.table(as.data.frame(mD), style = "rmarkdown",
              split.tables = Inf, caption = "Feature to standards matches")
 ```
 
-Only `r length(unique(mD$target_name))` standards of the `r nrow(std_dilution01)` 
-standards in mix `r `mix` have at least a feature that was matched to them. 
+For most of the standards (`r length(unique(mD$target_name))` out of 
+`r nrow(std_dilution01)`) in `r mix` at least one feature was found matching the
+standards adducts' m/z. 
+
+Below we plot the BPC indicating the position of the assigned features.
+
+```{r mix01-water-pos-bpc-matched, fig.path = IMAGE_PATH, echo = FALSE, caption = "Base peak chromatogram with position of features assigned to standards.", fig.width = 10, fig.height = 7}
+plot(bpc, peakType = "none", col = paste0(col_group[bpc$group], 80))
+legend("topright", col = col_group, lty = 1, legend = names(col_group))
+abline(v = mD$rtmed, lty = 2, col = "#00000080")
+```
+
+Position of some of the matching features overlap with regions in the BPC that
+exhibit a large difference in signal between high and low concentration.
 The standards with no match are reported below.
 
-```{r, results = "asis"}
+```{r, results = "asis", echo = FALSE}
 pandoc.table(std_dilution01[!std_dilution01$name %in% mD$target_name,
                             c("name", "formula", "RT", "POS", "NEG")],
              style = "rmarkdown", split.tables = Inf,
              caption = "Not matched standards")
 ```
+
+In the next sections we investigate for each standard which assignment would be
+the correct one or, for those for which no signal was detected, why that was the
+case.
+
+### Standards with matching features
+
+While for some standards a matching feature was found we still need to evaluate
+whether this matching makes sense. For each standard we thus first evaluate the
+EICs for all matching features, then we match their MS2 spectra (if available)
+against reference libraries.
+
+Annotation criteria:
+
+- 1: feature(s) was/were found with m/z matching those of adduct(s) of the
+  standard.
+- 2: signal is higher for samples with higher concentration.
+- 3: MS2 spectra matches reference library.
+
+We next load the reference libraries we will use for the MS2 matching. These are
+HMDB and MassBank.
+
+```{r}
+library(CompoundDb)
+
+cdb <- CompDb("data/CompDb.Hsapiens.HMDB.5.0.sqlite")
+
+library(MsBackendMassbank)
+library(RSQLite)
+con <- dbConnect(SQLite(), "data/MassBank.sqlite")
+mbank <- Spectra(con, source = MsBackendMassbankSql())
+```
+
+#### 3-Phosphoglyceric Acid
+
+```{r, echo = FALSE}
+std <- "3-Phosphoglyceric Acid"
+```
+
+```{r, results = "asis", echo = FALSE}
+tmp <- as.data.frame(mD[mD$target_name == std, ])
+pandoc.table(tmp, style = "rmarkdown",
+             split.tables = Inf, caption = "Feature to standards matches")
+```
+
+A considerable number of features has been assigned to this standard based on
+m/z matching. Based on their retention times, these seem however to represent
+ions from two different compounds.
+
+We next plot the EIC for the assigned feature and visually inspect these.
+
+```{r, echo = FALSE}
+eics <- featureChromatograms(data_WP, features = rownames(tmp))
+dr <- file.path(IMAGE_PATH, std)
+dir.create(dr, showWarnings = FALSE)
+col_sample <- col_group[eics$group]
+
+for (i in seq_len(nrow(eics))) {
+    ft <- rownames(tmp)[i]
+    fl <- file.path(dr, paste0("WP_", ft, ".png"))
+    png(fl, width = 12, height = 8, units = "cm", res = 300, pointsize = 6)
+    eic <- eics[i, ]
+    plot(eic, col = paste0(col_sample, 80),
+         peakBg = paste0(col_sample[chromPeaks(eic)[, "sample"]], 40))
+    abline(v = tmp$target_RT[1], lty = 2, col = "#00000060")
+    grid()
+    legend("topleft", c(std, tmp$adduct[i], ft))
+    legend("topright", col = col_group, legend = names(col_group), lty = 1)
+    dev.off()
+}
+```
+
+The EICs for the feature with the higher intensity for each of the two potential
+compounds are shown below.
+
+![](images/match-standards-mix01/3-Phosphoglyceric Acid/WP_FT1539.png)
+
+![](images/match-standards-mix01/3-Phosphoglyceric Acid/WP_FT1793.png)
+
+The peak shape is not perfect for neither of the two.
+
+Next we extract the MS2 spectra for all features and clean them (i.e. remove
+peaks with an intensity below 10% of the maximum peak and removing spectra with
+less than 2 peaks.
+
+```{r}
+#' Functions to process the spectra
+low_int <- function(x, ...) {
+    x > max(x, na.rm = TRUE) * 0.10
+}
+scale_int <- function(x, ...) {
+    maxint <- max(x[, "intensity"], na.rm = TRUE)
+    x[, "intensity"] <- 100 * x[, "intensity"] / maxint
+    x
+}
+
+extract_ms2 <- function(x, features) {
+    res <- featureSpectra(x, expandRt = 3, return.type = "Spectra",
+                          features = features)
+    res <- filterIntensity(res, intensity = low_int)
+    res <- res[lengths(res) > 1]
+    addProcessing(res, scale_int)
+}
+
+std_ms2 <- extract_ms2(data_WP, rownames(tmp))
+```
+
+The MS2 spectra are shown below.
+
+```{r mix01-water-3-phosphoglyceric-acid-ms2, fig.path = IMAGE_PATH, fig.cap = "MS2 spectra for features matched to 3-Phosphoglyceric Acid.", echo = FALSE}
+plotSpectra(std_ms2)
+```
+
+The MS2 spectra look rather busy with a large number of peaks. The first two
+belong to the first set of features with a retention time of about 250, the 3rd
+one to the second set of features with a retention time of ~ 200.
+
+Next we match the MS2 spectra against all reference spectra from HMDB and
+identify spectra with a similarity higher than 0.7.
+
+```{r}
+hmdb_match <- matchSpectra(
+    std_ms2, Spectra(cdb),
+    param = CompareSpectraParam(ppm = 50, requirePrecursor = FALSE))
+hmdb_match
+```
+
+No spectrum in HMDB matches any of the input spectra with a similarity higher
+than 0.7. We next we compare the experimental MS2 spectra against MassBank.
+
+```{r}
+mbank_match <- matchSpectra(
+    std_ms2, mbank,
+    param = CompareSpectraParam(ppm = 50, requirePrecursor = FALSE))
+mbank_match
+```
+
+Also for MassBank no match was found.
+
+As an alternative, we calculate also pairwise differences of the 3 experimental
+spectra against the MS2 spectra for `r std` from HMDB.
+
+```{r}
+hmdb_id <- std_dilution$HMDB.code[std_dilution$name == std]
+hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+
+sim <- compareSpectra(std_ms2, hmdb, ppm = 40)
+sim
+```
+
+The first two spectra match MS2 spectra for `r std` from HMDB with a similarity
+of about 0.4. These are shown in the mirror plots below.
+
+```{r mix01-water-3-phosphoglyceric-acid-mirror-hmdb, echo = FALSE, fig.cap = "Mirror plots"}
+par(mfrow = c(2, 2))
+plotSpectraMirror(std_ms2[1L], hmdb[8L], ppm = 40)
+plotSpectraMirror(std_ms2[1L], hmdb[14L], ppm = 40)
+plotSpectraMirror(std_ms2[2L], hmdb[8L], ppm = 40)
+plotSpectraMirror(std_ms2[2L], hmdb[14L], ppm = 40)
+```
+
+Although not perfect, it seems that feature 
+`r paste0(unique(std_ms2[1:2]$feature_id), collapse = ", ")` contains signal for
+an ion from `r std`.
+
+
+#### Acetylhistidine
+
+```{r, echo = FALSE}
+std <- "Acetylhistidine"
+```
+
+The table below lists all features that were matched to one of the adducts of 
+`r print(std)` that have in addition also on average a twice as high signal in
+samples with higher concentrations than in those with lower concentrations.
+
+```{r, results = "asis", echo = FALSE}
+tmp <- as.data.frame(mD[mD$target_name == std, ])
+tmp <- tmp[order(tmp$rtmed), ]
+pandoc.table(tmp, style = "rmarkdown",
+             split.tables = Inf, caption = "Feature to standards matches")
+```
+
+Based on their retention time, it seems that these features represent signal
+from 4 different compounds.
+
+We next plot the EIC for the assigned feature and visually inspect these.
+
+```{r, echo = FALSE}
+eics <- featureChromatograms(data_WP, features = rownames(tmp))
+dr <- file.path(IMAGE_PATH, std)
+dir.create(dr, showWarnings = FALSE)
+col_sample <- col_group[eics$group]
+
+for (i in seq_len(nrow(eics))) {
+    ft <- rownames(tmp)[i]
+    fl <- file.path(dr, paste0("WP_", ft, ".png"))
+    png(fl, width = 12, height = 8, units = "cm", res = 300, pointsize = 6)
+    eic <- eics[i, ]
+    plot(eic, col = paste0(col_sample, 80),
+         peakBg = paste0(col_sample[chromPeaks(eic)[, "sample"]], 40))
+    abline(v = tmp$target_RT[1], lty = 2, col = "#00000060")
+    grid()
+    legend("topleft", c(std, tmp$adduct[i], ft))
+    legend("topright", col = col_group, legend = names(col_group), lty = 1)
+    dev.off()
+}
+```
+
+Again, we show a representative EIC for each *feature group* (ordered by
+retention time).
+
+![](images/match-standards-mix01/Acetylhistidine/WP_FT1633.png)
+
+![](images/match-standards-mix01/Acetylhistidine/WP_FT1926.png)
+
+![](images/match-standards-mix01/Acetylhistidine/WP_FT1643.png)
+
+![](images/match-standards-mix01/Acetylhistidine/WP_FT1644.png)
+
+Feature FT1926 can clearly not represent signal from `r std`. We next extract
+the MS2 spectra for all these features and match them against the reference
+spectra for `r std` from HMDB.
+
+```{r mix01-water-acetylhistidine-ms2, fig.path = IMAGE_PATH, fig.cap = "MS2 spectra for features matched to acetylhistidine.", echo = FALSE}
+std_ms2 <- extract_ms2(data_WP, rownames(tmp))
+
+plotSpectra(std_ms2)
+```
+
+We have thus MS2 spectra for each set of features. Next we compare them against
+the reference spectra for `r std` from HMDB. The results are shown in the
+heatmap below.
+
+```{r mix01-water-acetylhistidine-ms2-hmdb-heatmap, fig.path = IMAGE_PATH, fig.cap = "Similarities of MS2 spectra for selected features against reference spectra for Acetylhistidine from HMDB."}
+hmdb_id <- std_dilution$HMDB.code[std_dilution$name == std]
+hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+
+sim <- compareSpectra(std_ms2, hmdb, ppm = 40)
+
+ann <- data.frame(feature_id = std_ms2$feature_id, rt = rtime(std_ms2))
+rownames(ann) <- rownames(sim)
+
+library(pheatmap)
+pheatmap(sim, annotation_row = ann, breaks = seq(0, 1, length.out = 101),
+         color = colorRampPalette((brewer.pal(n = 7, name = "YlOrRd")))(100))
+```
+
+The MS2 spectra for FT1643 have the highest similarity against MS2 spectra from
+`r std`.
+
+In addition we match the MS2 spectra for the matched features against all
+spectra from HMDB.
+
+```{r}
+hmdb_match <- matchSpectra(
+    std_ms2, Spectra(cdb),
+    param = CompareSpectraParam(ppm = 50, requirePrecursor = FALSE))
+hmdb_match
+```
+
+```{r}
+hmdb_match <- hmdb_match[whichQuery(hmdb_match)]
+
+tab <- spectraData(hmdb_match, c("feature_id", "rtime", "target_name", "score"))
+pandoc.table(as.data.frame(tab), style = "rmarkdown", split.table = Inf)
+```
+
+The features with a retention time of about 37 seconds are clearly not `r std`
+while those with a retention time of about 180 seconds seem to represent signal
+for that compound, even if their MS2 spectra match also reference spectra from
+other compounds.
+
+
+
+
+### Standards without any matching feature
+
+
+## Alternative
+
+Sort of a reverse approach. Instead of starting with MS1 we start with MS2.
+
+- use all MS/MS spectra, clean them, normalize them and match them against HMDB
+  and MassBank.
+- Determine which of them match to standards.
+- Get their retention time and look for features that are close by.
+- If features also exhibit a difference between concentrations AND the m/z
+  matches those of an adduct of the standard -> Bingo.
 
 ### A subsection for each of these standards to investigate why no match was found for them?
 


### PR DESCRIPTION
This PR introduces some changes to the matching of standards:
- Tune pre-processing settings (including alignment) to identify more features.
- Manually evaluate matched features for each standard.