### PR TITLE
Add ions and MS2 spectra for Mix 02 to database

### DIFF
--- a/R/match-standards-chunks.R
+++ b/R/match-standards-chunks.R
@@ -13,8 +13,8 @@ library(RColorBrewer)
 library(MetaboAnnotation)
 library(pheatmap)
 library(MsFeatures)
-setMSnbaseFastLoad(TRUE)
-# setMSnbaseFastLoad(FALSE)
+# setMSnbaseFastLoad(TRUE)
+setMSnbaseFastLoad(FALSE)
 register(SerialParam())
 source("R/match-standards-functions.R")
 
@@ -30,7 +30,7 @@ dir.create(IMAGE_PATH, showWarnings = FALSE, recursive = TRUE)
 dir.create(RDATA_PATH, showWarnings = FALSE, recursive = TRUE)
 #' Define the mzML files *base* path (/data/massspec/mzML/ on the cluster)
 MZML_PATH <- "/Volumes/PortableSSD/mzML/"
-# MZML_PATH <- "/data/massspec/mzML/"
+MZML_PATH <- "/data/massspec/mzML/"
 ALL_NL_MATCH <- FALSE                   # run matching against neutral loss db
 library(knitr)
 opts_chunk$set(cached = FALSE, message = FALSE, warning = FALSE,
@@ -247,7 +247,8 @@ pandoc.table(std_dilution[!std_dilution$name %in% mD$target_name,
 feature_table <- as.data.frame(mD[mD$target_name == std, ])
 feature_table <- feature_table[order(feature_table$rtmed), ]
 feature_table$feature_group <- group_features(data_FS, rownames(feature_table))
-std_ms2 <- extract_ms2(data, rownames(feature_table))
+std_ms2 <- extract_ms2(data, rownames(feature_table), ppm = FEATURE_MS2_PPM,
+                       tolerance = FEATURE_MS2_TOLERANCE)
 feature_table$n_ms2 <- 0
 if(length(std_ms2)) {
    nms2 <- table(std_ms2$feature_id)

--- a/R/match-standards-chunks.R
+++ b/R/match-standards-chunks.R
@@ -247,6 +247,7 @@ pandoc.table(std_dilution[!std_dilution$name %in% mD$target_name,
 feature_table <- as.data.frame(mD[mD$target_name == std, ])
 feature_table <- feature_table[order(feature_table$rtmed), ]
 feature_table$feature_group <- group_features(data_FS, rownames(feature_table))
+FEATURE_MS2_TOLERANCE = 0.4
 std_ms2 <- extract_ms2(data, rownames(feature_table), ppm = FEATURE_MS2_PPM,
                        tolerance = FEATURE_MS2_TOLERANCE)
 feature_table$n_ms2 <- 0
@@ -261,7 +262,7 @@ pandoc.table(feature_table[, c("mzmed", "ppm_error", "rtmed", "target_RT",
              caption = paste0("Feature to standards matches for ", std))
 
 
-## ---- add-ions ----
+## ---- add-ions ----a
 stopifnot(all(fts$feature_id %in% rownames(feature_table)))
 fts$sample_matrix <- MATRIX
 fts$original_sample <- paste0("Std_", MIX_NAME)

--- a/R/match-standards-chunks.R
+++ b/R/match-standards-chunks.R
@@ -247,7 +247,6 @@ pandoc.table(std_dilution[!std_dilution$name %in% mD$target_name,
 feature_table <- as.data.frame(mD[mD$target_name == std, ])
 feature_table <- feature_table[order(feature_table$rtmed), ]
 feature_table$feature_group <- group_features(data_FS, rownames(feature_table))
-FEATURE_MS2_TOLERANCE = 0.4
 std_ms2 <- extract_ms2(data, rownames(feature_table), ppm = FEATURE_MS2_PPM,
                        tolerance = FEATURE_MS2_TOLERANCE)
 feature_table$n_ms2 <- 0
@@ -262,7 +261,7 @@ pandoc.table(feature_table[, c("mzmed", "ppm_error", "rtmed", "target_RT",
              caption = paste0("Feature to standards matches for ", std))
 
 
-## ---- add-ions ----a
+## ---- add-ions ----
 stopifnot(all(fts$feature_id %in% rownames(feature_table)))
 fts$sample_matrix <- MATRIX
 fts$original_sample <- paste0("Std_", MIX_NAME)
@@ -305,7 +304,7 @@ fts <- do.call(rbind, lapply(fts, function(z) {
                rt = mean(z$ion_rt))
 }))
 sps <- Spectra(idb)
-sps <- sps[sps$original_file %in% basename(fls)]
+sps <- sps[sps$original_file %in% basename(fileNames(data_all))]
 n_ms2 <- table(sps$compound_id)
 idx <- match(rownames(fts), std_dilution$HMDB)
 fts <- cbind(name = std_dilution[idx, "name"],

--- a/R/match-standards-functions.R
+++ b/R/match-standards-functions.R
@@ -60,9 +60,9 @@ plot_spectra <- function(x) {
     } else cat("No MS2 spectra.")
 }
 
-extract_ms2 <- function(x, features, ppm = 20) {
+extract_ms2 <- function(x, features, ppm = 20, tolerance = 0) {
     res <- featureSpectra(x, expandRt = 3, return.type = "Spectra",
-                          features = features, ppm = ppm)
+                          features = features, ppm = ppm, expandMz = tolerance)
     res <- filterIntensity(res, intensity = low_int)
     res <- res[lengths(res) > 1]
     if (!length(res))

--- a/data/standards_dilution.txt
+++ b/data/standards_dilution.txt
@@ -1,257 +1,257 @@
-mix	name	abbreviation	HMDB.code	formula	POS	NEG	RT	data_set	sample	operator	version	quality_POS	quality_NEG
-1	Acetylhistidine	acetylhistidine	HMDB0032055	C8H11N3O3	[M+H]+	[M-H]-	180	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-1	Betaine	betaine	HMDB0000043	C5H11NO2	[M+H]+	[M+CHO2]-	166	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-1	C3 Carnitine	carnitine_c3	HMDB0000824	C10H19NO4	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-1	CDP	CDP	HMDB0001546	C9H15N3O11P2	NA	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-1	Creatine	creatine	HMDB0000064	C4H9N3O2	[M+H]+	[M-H]-	173	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-1	Dimethylglycine	dimethylglycine	HMDB0000092	C4H9NO2	[M+H]+	[M-H]-	177	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-1	L-Glutamic Acid	glutamic	HMDB0000148	C5H9NO4	[M+H]+	[M-H]-	176	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-1	Glycerol	glycerol	HMDB0000131	C3H8O3	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad
-1	Myo-Inositol	myoinositol	HMDB0000211	C6H12O6	[M+Na]+	[M+CHO2]-	193	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-1	3-Phosphoglyceric Acid	phosphoglyceric_3	HMDB0000807	C3H7O7P	[M+H]+	[M-H]-	267	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-1	propionic acid	propionic	HMDB0000237	C3H6O2	NA	[M-H]-	53	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-1	Pyruvic Acid	pyruvic	HMDB0000243	C3H4O3	NA	[M-H]-	41	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-1	Suberic Acid	suberic	HMDB0000893	C8H14O4	[M+Na]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-1	Uric acid	uric	HMDB0000289	C5H4N4O3	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad
-1	Xanthine	xanthine	HMDB0000292	C5H4N4O2	[M+H]+	[M-H]-	140	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-2	Ascorbic Acid	ascorbic	HMDB0000044	C6H8O6	[M+H]+	[M-H]-	128	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-2	C4 Carnitine	carnitine_c4	HMDB0000736	C11H21NO4	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-2	Fructose	fructose	HMDB0000660	C6H12O6	[M+Na]+	[M-H]-	150	2020_01_matrix_effect	serum	Vinicius	2	2_medium	2_medium
-2	Glycine	glycine	HMDB0000123	C2H5NO2	[M+H]+	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-2	cGMP	GMP_c	HMDB0001314	C10H12N5O7P	[M+H]+	[M-H]-	217	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-2	Histidine	histidine	HMDB0000177	C6H9N3O2	[M+H]+	[M-H]-	188	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-2	Hydroxyproline	hydroxyproline	HMDB0000725	C5H9NO3	[M+H]+	[M-H]-	175	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-2	Hypoxanthine	hypoxanthine	HMDB0000157	C5H4N4O	[M+H]+	[M-H]-	126	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-2	L-Kynurenine	kynurenine	HMDB0000684	C10H12N2O3	[M+H]+	[M-H]-	157	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-2	Lactic acid	lactic	HMDB0000190	C3H6O3	NA	[M-H]-	38	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-2	1-Methylxanthine	methylxanthine_1	HMDB0010738	C6H6N4O2	[M+H]+	[M-H]-	80	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-2	3-Nitrotyrosine	nitrotyrosine	HMDB0001904	C9H10N2O5	[M+H]+	[M-H]-	157	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-2	Phosphocreatine	phosphocreatine	HMDB0001511	C4H10N3O5P	[M+H]+	[M-H]-	198	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-2	UDP-glucuronate	UDP_glucuronate	HMDB0000935	C15H22N2O18P2	[M+NH4]+	[M-H]-	323	2020_01_matrix_effect	water	Vinicius	2	3_bad	3_bad
-2	Valine	valine	HMDB0000883	C5H11NO2	[M+H]+	[M-H]-	166	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-3	Acetyl-CoA	acetylcoa	HMDB0001206	C23H38N7O17P3S	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-3	Adenylosuccinic Acid	adenylosuccinic	HMDB0000536	C14H18N5O11P	[M+H]+	[M-H]-	250	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-3	Alanine	alanine	HMDB0000161	C3H7NO2	[M+H]+	[M-H+HCOONa]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-3	Citrulline	citrulline	HMDB0000904	C6H13N3O3	[M+H]+	[M-H]-	182	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-3	Cytosine	cytosine	HMDB0000630	C4H5N3O	[M+H]+	[M-H]-	153	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-3	Glucose	glucose	HMDB0000122	C6H12O6	[M+Na]+	[M+CHO2]-	167	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-3	Glutathione Oxidized	glutathione_oxidized	HMDB0003337	C20H32N6O12S2	[M+H]+	[M-H]-	212	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-3	Glycolic acid	glycolic	HMDB0000115	C2H4O3	NA	[M-H]-	49	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-3	Guanine	guanine	HMDB0000132	C5H5N5O	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-3	Isoleucine	isoleucine	HMDB0000172	C6H13NO2	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-3	Malonic acid	malonic	HMDB0000691	C3H4O4	NA	[M-H]-	63	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-3	Niacinamide	niacinamide	HMDB0001406	C6H6N2O	[M+H]+	NA	50	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-3	5-Oxoproline	oxoproline	HMDB0000267	C5H7NO3	[M+H]+	[M-H]-	71	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-3	Palmitoylcarnitine	palmitoylcarnitine	HMDB0000222	C23H45NO4	[M+H]+	[M+CHO2]-	34	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	2_medium	3_bad
-3	UDP	UDP	HMDB0000295	C9H14N2O12P2	NA	NA	238	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-4	Acetylalanine	acetylalanine_NL	HMDB0000766	C5H9NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-4	Allantoin	allantoin	HMDB0000462	C4H6N4O3	[M+H]+	[M-H]-	139	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-4	Gamma-Aminobutyric acid	aminobutyric	HMDB0000112	C4H9NO2	[M+H]+	NA	144	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-4	AMP	AMP	HMDB0000045	C10H14N5O7P	[M+H]+	[2M-H]-	212	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good
-4	Glutamine	glutamine	HMDB0000641	C5H10N2O3	[M+H]+	[M-H]-	178	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-4	GMP	GMP	HMDB0001397	C10H14N5O8P	[M+H]+	[M-H]-	229	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-4	Leucine	leucine	HMDB0000687	C6H13NO2	[M+H]+	[M-H]-	152	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-4	Phenylethylamine	phenylethylamine	HMDB0012275	C8H11N	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-4	Propylene glycol	propylene_glycol	HMDB0001881	C3H8O2	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-4	Putrescine	putrescine	HMDB0001414	C4H12N2	[M+H-NH3]+	NA	173	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-4	Pyridoxine	pyridoxine	HMDB0000239	C8H11NO3	[M+H]+	[M-H]-	123	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-4	Riboflavin	riboflavin	HMDB0000244	C17H20N4O6	[M+H]+	[M-H]-	145	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-4	Ribose	ribose	HMDB0000283	C5H10O5	NA	[M-H]-	100	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-4	SAMe	SAMe	HMDB0001185	C15H23N6O5S	[M+H]+	NA	193	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	3_bad
-4	Sedoheptulose-7-phosphate	sedoheptulose_phosphate	HMDB0001068	C7H15O10P	[M+H-H2O]+	[2M-H]-	235	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-5	dADP	ADP_d	HMDB0001508	C10H15N5O9P2	[M+H]+	[M-H]-	260	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-5	dCDP	CDP_d	HMDB0001245	C9H15N3O10P2	[M+H]+	[M-H]-	260	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-5	CoA	CoA	HMDB0001423	C21H36N7O16P3S	NA	[M-H]-	203	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-5	Corticosterone	corticosterone	HMDB0001547	C21H30O4	[M+H]+	[M+CHO2]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	3_bad
-5	"1,3-Dimethyluric acid"	dimethyluric_1_3	HMDB0001857	C7H8N4O3	[M+H]+	[M-H]-	100	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-5	Glycerophospho-inositol	glycerophospho_inositol	HMDB0011649	C9H19O11P	[M+H]+	[M-H]-	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	NA	NA
-5	GTP	GTP	HMDB0001273	C10H16N5O14P3	NA	[M-H]-	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-5	2-Ketobutyric acid	ketobutyric_2	HMDB0000005	C4H6O3	NA	[M-H]-	39	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-5	Mannose	mannose	HMDB0000169	C6H12O6	[M+Na]+	[M+CHO2]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-5	5-MTA	MTA	HMDB0001173	C11H15N5O3S	[M+H]+	[M+CHO2]-	80	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-5	NADP	NADP	HMDB0000217	C21H28N7O17P3	[M+H]+	[M-H]-	280	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-5	Nicotinic acid	nicotinic	HMDB0001488	C6H5NO2	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-5	Orotic acid	orotic	HMDB0000226	C5H4N2O4	[M+H]+	[M-H]-	177	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-5	PABA	PABA	HMDB0001392	C7H7NO2	[M+H]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	2_medium
-5	Threonine	threonine	HMDB0000167	C4H9NO3	[M+H]+	[M-H]-	173	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-6	Acetylglutamic acid	acetylglutamic	HMDB0001138	C7H11NO5	[M+H]+	[M-H]-	87	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-6	Acetylglycine	acetylglycine	HMDB0000532	C4H7NO3	[M+H]+	[M-H]-	54	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-6	Arginine	arginine	HMDB0000517	C6H14N4O2	[M+H]+	[M-H]-	187	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good
-6	Asparagine	asparagine	HMDB0000168	C4H8N2O3	[M+H]+	[M-H]-	183	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-6	Choline	choline	HMDB0000097	C5H13NO	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-6	CMP	CMP	HMDB0000095	C9H14N3O8P	[M+H]+	[M-H]-	211	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-6	Cystine	cystine	HMDB0000192	C6H12N2O4S2	[M+H]+	[M-H]-	211	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-6	Histamine	histamine	HMDB0000870	C5H9N3	[M+H]+	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-6	3-Hydroxybutyric Acid	hydroxybutyric_3	HMDB0000357	C4H8O3	[M+Na]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect
-6	Methioninesulfoxide	methionine_sulfoxide	HMDB0002005	C5H11NO3S	[M+H]+	[M-H]-	182	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-6	Paracetamol	paracetamol	HMDB0001859	C8H9NO2	[M+H]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-6	Sphingosine-1-phosphate	sphingosine_phosphate	HMDB0000277	C18H38NO5P	[M+H]+	[M-H]-	145	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-6	Sucrose	sucrose	HMDB0000258	C12H22O11	[M+Na]+	[M+CHO2]-	187	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-6	Tryptophan	tryptophan	HMDB0000929	C11H12N2O2	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-6	UDP-acetylglucosamine	UDP_acetylglucosamine	HMDB0000290	C17H27N3O17P2	[M+H]+	[M-H]-	331	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-7	ADMA	ADMA	HMDB0001539	C8H18N4O2	[M+H]+	[M-H]-	176	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	dAMP	AMP_d	HMDB0000905	C10H14N5O6P	[M+H]+	[M-H]-	208	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	Caffeine	caffeine	HMDB0001847	C8H10N4O2	[M+H]+	NA	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	3_bad
-7	CDP-choline	CDP_choline	HMDB0001413	C14H26N4O11P2	[M+H]+	[M+CHO2]-	217	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	Creatinine	creatinine	HMDB0000562	C4H7N3O	[M+H]+	[M-H]-	87	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-7	Glutaric acid	glutaric	HMDB0000661	C5H8O4	NA	[M-H]-	38	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-7	Glycero-phosphocholine	glycero_phosphocholine	HMDB0000086	C8H20NO6P	[M+H]+	[M+Cl]-	189	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	Methionine	methionine	HMDB0000696	C5H11NO2S	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	3-Methylhistidine	methylhistidine_3	HMDB0000479	C7H11N3O2	[M+H]+	[M-H]-	186	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	1-Methyluric acid	methyluric	HMDB0003099	C6H6N4O3	[M+H]+	[M-H]-	145	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good
-7	Phenylpyruvic acid	phenylpyruvic	HMDB0000205	C9H8O3	[M+H-H2O]+	[M-H]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-7	Serine	serine	HMDB0000187	C3H7NO3	[M+H]+	[M-H]-	181	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	Sphingosine	sphingosine	HMDB0000252	C18H37NO2	[M+H]+	[M+CHO2]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	3_bad
-7	Taurine	taurine	HMDB0000251	C2H7NO3S	[M+H]+	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-7	Threonic Acid	threonic	HMDB0000943	C4H8O5	[M+Na]+	[M-H]-	130	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-8	Aspirin	aspirin	HMDB0001879	C9H8O4	NA	[M-H]-	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-8	Biotin	biotin	HMDB0000030	C10H16N2O3S	[M+H]+	[M-H]-	72	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-8	C5 Carnitine	carnitine_c5	HMDB0000688	C12H23NO4	[M+H]+	NA	47	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-8	Cystathionine	cystathionine	HMDB0000099	C7H14N2O4S	[M+H]+	[M-H]-	207	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-8	"5,6-Dihydro Thymine"	dihydrothymine	HMDB0000079	C5H8N2O2	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-8	dGDP	GDP_d	HMDB0000960	C10H15N5O10P2	[M+H]+	[M-H]-	260	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-8	Glyceric Acid	glyceric	HMDB0000139	C3H6O4	NA	[M-H]-	75	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-8	Inosine	inosine	HMDB0000195	C10H12N4O5	[M+Na]+	[M-H]-	146	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-8	Mevalonic Acid	mevalonic	HMDB0000227	C6H12O4	[M+H-H2O]+	[M-H]-	48	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-8	NADPH	NADPH	HMDB0000221	C21H30N7O17P3	NA	NA	207	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-8	Norepinephrine	norepinephrine	HMDB0000216	C8H11NO3	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-8	Ornithine	ornithine	HMDB0000214	C5H12N2O2	[M+H]+	[M-H]-	190	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-8	Succinic Acid	succinic	HMDB0000254	C4H6O4	NA	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-8	Tyrosine	tyrosine	HMDB0000158	C9H11NO3	[M+H]+	[M-H]-	168	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-8	Uracil	uracil	HMDB0000300	C4H4N2O2	[M+H]+	[M-H]-	64	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-9	N-Acetylserine	acetylserine	HMDB0002931	C5H9NO4	[M+H]+	[M-H]-	82	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	ADP-Ribose	ADP_ribose	HMDB0001178	C15H23N5O14P2	[M+H]+	[M-H]-	270	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-9	CDP-ethanolamine	CDP_ethanolamine	HMDB0001564	C11H20N4O11P2	[M+H]+	[M-H]-	219	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-9	CTP	CTP	HMDB0000082	C9H16N3O14P3	NA	[M-H]-	232	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-9	L-Cysteine	cysteine	HMDB0000574	C3H7NO2S	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	Diethyl malonate	diethylmalonate	HMDB0029573	C7H12O4	[M+H]+	NA	29	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-9	Eplerone	eplerone	HMDB0014838	C24H30O6	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	NA	NA
-9	Erythrose 4-phosphate	erythrose_phosphate	HMDB0001321	C4H9O7P	[M+Na]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-9	Glucose 1-Phosphate	glucose_phosphate_1	HMDB0000645	C6H13O9P	[2M+H]+	[2M-H]-	237	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	Guanosine	guanosine	HMDB0000133	C10H13N5O5	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-9	IMP	IMP	HMDB0000175	C10H13N4O8P	[M+H]+	[M-H]-	226	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	NADH	NADH	HMDB0001487	C21H29N7O14P2	[M+H]+	[M-H]-	265	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	Pipecolic acid	pipecolic	HMDB0000070	C6H11NO2	[M+H]+	[M-H]-	169	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	Proline	proline	HMDB0000162	C5H9NO2	[M+H]+	[M-H]-	169	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-9	Thymidine	thymidine	HMDB0000273	C10H14N2O5	[M+Na]+	[M-H]-	72	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-10	N-Acetylornithine	acetylornithine	HMDB0003357	C7H14N2O3	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-10	Adenosine	adenosine	HMDB0000050	C10H13N5O4	[M+H]+	[M+CHO2]-	134	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-10	L-Aspartic Acid	aspartic	HMDB0000191	C4H7NO4	[M+H]+	[M-H]-	181	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-10	Citric Acid	citric	HMDB0000094	C6H8O7	[M+Na]+	[M-H]-	177	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-10	Cytidine	cytidine	HMDB0000089	C9H13N3O5	[M+H]+	[M+CHO2]-	162	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-10	Fumaric Acid	fumaric	HMDB0000134	C4H4O4	NA	[M-H]-	48	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-10	GDP	GDP	HMDB0001201	C10H15N5O11P2	[M+H]+	[M-H]-	295	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-10	Glucosamine	glucosamine	HMDB0001514	C6H13NO5	[M+H]+	[M+CHO2]-	181	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-10	Phosphoenolpyruvic Acid	phosphoenolpyruvic	HMDB0000263	C3H5O6P	[M+H]+	[M-H]-	227	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-10	Phosphorylethanolamine	phosphorylethanolamine	HMDB0000224	C2H8NO4P	[M+H]+	[2M-H]-	198	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good
-10	Ribulose 5-Phosphate	ribulose_phosphate	HMDB0000618	C5H11O8P	[M+H]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-10	SAH	SAH	HMDB0000939	C14H20N6O5S	[M+H]+	[M-H]-	186	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-10	Salicylic acid	salicylic	HMDB0001895	C7H6O3	[M+H]+	[M-H]-	34	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	0_perfect
-10	Spermidine	spermidine	HMDB0001257	C7H19N3	[M+H]+	NA	188	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-10	Thymine	thymine	HMDB0000262	C5H6N2O2	[M+H]+	[M-H]-	58	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-11	ADP	ADP	HMDB0001341	C10H15N5O10P2	[M+H]+	[M-H]-	256	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-11	L-Carnitine	carnitine	HMDB0000062	C7H15NO3	[M+H]+	NA	130	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-11	dCTP	CTP_d	HMDB0000998	C9H16N3O13P3	NA	[M-H]-	228	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-11	"L,L-Cyclo(leucylprolyl)"	cyclo_leucylprolyl	HMDB0034276	C11H18N2O2	[M+H]+	NA	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	3_bad
-11	Dihydroorotic acid	dihydroorotic	HMDB0003349	C5H6N2O4	[M+H]+	[M-H]-	120	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-11	Glutathione Reduced	glutathione_reduced	HMDB0000125	C20H32N6O12S2	[M+H]+	[M-H]-	211	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-11	Alpha-ketoisovaleric acid	ketoisovaleric	HMDB0000019	C5H8O3	NA	[M-H]-	34	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-11	Lysine	lysine	HMDB0000182	C6H14N2O2	[M+H]+	[M-H]-	188	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-11	Malic Acid	malic	HMDB0000156	C4H6O5	NA	[M-H]-	92	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-11	3-Methylxanthine	methylxanthine_3	HMDB0001886	C6H6N4O2	[M+H]+	[M-H]-	86	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-11	2-Phosphoglyceric Acid	phosphoglyceric_2	HMDB0000362	C3H7O7P	[M+H]+	[M-H]-	250	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-11	SDMA	SDMA	HMDB0003334	C8H18N4O2	[M+H]+	[M-H]-	174	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-11	Tetrahydrobiopterin	tetrahydrobiopterin	HMDB0000027	C9H15N5O3	[M+Na]+	NA	141	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad
-11	p-Tyramine	tyramine	HMDB0000306	C8H11NO	[M+H]+	NA	127	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-11	UDP-Glucose	UDP_glucose	HMDB0000286	C15H24N2O17P2	[M+Na]+	[M-H]-	305	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	2_medium
-12	Argininosuccinic acid	argininosuccinic	HMDB0000052	C10H18N4O6	[M+H]+	[M-H]-	199	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-12	Carnosine	carnosine	HMDB0000033	C9H14N4O3	[M+H]+	[M-H]-	184	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-12	dCMP	CMP_d	HMDB0001202	C9H14N3O7P	[M+H]+	[2M-H]-	203	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-12	Folic acid	folic	HMDB0000121	C19H19N7O6	[M+Na]+	[M-H]-	160	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-12	N-Formyl-L-methionine	formylmethionine	HMDB0001015	C6H11NO3S	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-12	Galactitol	galactitol	HMDB0000107	C6H14O6	[M+Na]+	[M-H]-	167	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-12	Glucose 6-Phosphate	glucose_phosphate_6	HMDB0001401	C6H13O9P	[2M+H]+	[2M-H]-	239	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-12	dGMP	GMP_d	HMDB0001044	C10H14N5O7P	[M+H]+	[M-H]-	223	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-12	Guanidoacetic acid	guanidoacetic	HMDB0000128	C3H7N3O2	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-12	Homocysteine	homocysteine	HMDB0000742	C4H9NO2S	[M+H]+	[M-H]-	168	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-12	Ketoleucine	ketoleucine	HMDB0000695	C6H10O3	[M+H]+	[M-H]-	34	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-12	Methotrexate	methotrexate	HMDB0014703	C20H22N8O5	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-12	Sebacic acid	sebacic	HMDB0000792	C10H18O4	[M+Na]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-12	Thiamine	thiamine	HMDB0000235	C12H16N4OS	[M+H]+	[M-H]-	148	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-12	Tryptamine	tryptamine	HMDB0000303	C10H12N2	[M+H-NH3]+	NA	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-13	N-Acetyl-beta-alanine	acetylalanine_NB	HMDB0061880	C5H9NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-13	Acetylneuraminic Acid	acetylneuraminic	HMDB0000230	C11H19NO9	[M+H-H4O2]+	[M-H]-	180	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-13	Dopamine	dopamine	HMDB0000073	C8H11NO2	[M+H]+	[M-H]-	140	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-13	"Fructose-1,6-Diphosphate"	fructose_diphosphate	HMDB0001058	C6H14O12P2	[M+H-H2O]+	[M-H]-	330	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad
-13	Ibuprofen	ibuprofen	HMDB0001925	C13H18O2	NA	[M-H]-	31	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect
-13	Indoleacetic acid	indoleacetic	HMDB0000197	C10H9NO2	[M+H]+	[M-H]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-13	1-Methylhistidine	methylhistidine_1	HMDB0000001	C7H11N3O2	[M+H]+	[M-H]-	182	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-13	8-Oxo-2-Deoxyguanosine	oxodeoxyguanosine	HMDB0003333	C10H13N5O5	[M+H]+	[M-H]-	159	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-13	Pantothenic Acid	pantothenic	HMDB0000210	C9H17NO5	[M+H]+	[M-H]-	38	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-13	Phenylacetic acid	phenylacetic	HMDB0000209	C8H8O2	[M+H]+	[M-H]-	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-13	Phosphorylcholine	phosphorylcholine	HMDB0001565	C5H14NO4P	[M+H]+	[M+Cl]-	195	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-13	Sorbitol	sorbitol	HMDB0000247	C6H14O6	[M+Na]+	[M-H]-	165	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-13	Spermine	spermine	HMDB0001256	C10H26N4	[M+H]+	NA	204	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-13	Uridine	uridine	HMDB0000296	C9H12N2O6	[M+H]+	[M+CHO2]-	124	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-13	dUTP	UTP_d	HMDB0001191	C9H15N2O14P3	NA	NA	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-14	Acetylcarnitine	acetylcarnitine	HMDB0000201	C9H17NO4	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-14	ADP-Glucose	ADP_glucose	HMDB0006557	C16H25N5O15P2	[M+H-Hexose-H2O]+	[M-H]-	275	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-14	"1,5-anhydro D-glucitol"	anhydroglucitol	HMDB0002712	C6H12O5	[M+Na]+	[M+CHO2]-	135	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-14	Glyceraldehyde 2-phosphate	glyceraldehyde_phosphate	HMDB0001112	C3H7O6P	[M+H]+	[M-H]-	213	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-14	Glycerol-3-Phosphate	glycerol_phosphate	HMDB0000126	C3H9O6P	[M+H]+	[2M-H]-	222	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-14	dGTP	GTP_d	HMDB0001440	C10H16N5O13P3	NA	NA	233	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-14	Indolelactic acid	indolelactic	HMDB0000671	C11H11NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-14	Isocitric Acid	isocitric	HMDB0000193	C6H8O7	NA	[M-H]-	146	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-14	2-Ketoglutaric acid	ketoglutaric_2	HMDB0000208	C5H6O5	NA	[M-H]-	75	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-14	Levodopa	levodopa	HMDB0000181	C9H11NO4	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-14	NAD	NAD	HMDB0000902	C21H27N7O14P2	[M+H]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-14	Pyridoxic Acid	pyridoxic	HMDB0000017	C8H9NO4	[M+H]+	[M-H]-	85	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-14	Serotonin	serotonin	HMDB0000259	C10H12N2O	[M+H-NH3]+	[M+Cl]-	132	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-14	Ureidopropionic acid	ureidopropionic	HMDB0000026	C4H8N2O3	[M+H]+	[M-H]-	88	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-14	Xylulose 5-Phosphate	xylulose_phosphate	HMDB0000868	C5H11O8P	[M+H]+	[2M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-15	N-alpha-Acetyl-L-arginine	acetylarginine	HMDB0004620	C8H16N4O3	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-15	alpha-Aminoadipic acid	aminoadipic	HMDB0000510	C6H11NO4	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-15	FAD	FAD	HMDB0001248	C27H33N9O15P2	[M+H]+	[M-H]-	290	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-15	Glucosamine-6-Phosphate	glucosamine_phosphate	HMDB0001254	C6H14NO8P	[M+H]+	[2M-H]-	219	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-15	Glucuronic Acid	glucuronic	HMDB0000127	C6H10O7	[M+Na]+	[M-H]-	171	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect
-15	p-Hydroxyphenylacetic acid	hydroxyphenylacetic	HMDB0000020	C8H8O3	[M+H-H2O]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-15	Isovalerylglycine	isovalerylglycine	HMDB0000678	C7H13NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-15	2-Methylcitric acid	methylcitric	HMDB0000379	C7H10O7	[M+Na]+	[M-H]-	171	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-15	Phenylalanine	phenylalanine	HMDB0000159	C9H11NO2	[M+H]+	[M-H]-	154	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-15	Phosphoserine	phosphoserine	HMDB0000272	C3H8NO6P	[M+H]+	[2M-H]-	231	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-16	Acetyl-Glucosamine	acetylglucosamine	HMDB0000215	C8H15NO6	[M+Na]+	[M+CHO2]-	156	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-16	Acetylmethionine	acetylmethionine	HMDB0011745	C7H13NO3S	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-16	Dihydroxyacetone phosphate	dihydroxyacetone_phosphate	HMDB0001473	C3H7O6P	[M+H]+	[2M-H]-	220	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-16	"1,7-Dimethyluric acid"	dimethyluric_1_7	HMDB0011103	C7H8N4O3	[M+H]+	[M-H]-	119	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-16	homovanillic acid	homovanillic	HMDB0000118	C9H10O4	[M+H-CH2O2]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect
-16	6-Phosphogluconic Acid	phosphogluconic	HMDB0001316	C6H13O10P	[M+H-H2O]+	[M-H]-	265	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-16	Quinolinic acid	quinolinic	HMDB0000232	C7H5NO4	[M+H]+	[M-H]-	176	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-17	Acetylaspartic acid	acetylaspartic	HMDB0000812	C6H9NO5	[M+H]+	[M-H]-	100	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good
-17	dATP	ATP_d	HMDB0001532	C10H16N5O12P3	NA	[M-H]-	224	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-17	Epinephrine	epinephrine	HMDB0000068	C9H13NO3	[M+H]+	[M-H]-	144	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-17	Gluconic Acid	gluconic	HMDB0000625	C6H12O7	[M+Na]+	[M-H]-	171	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium
-17	3-Hydroxy-DL-kynurenine	hydroxykynurenine_3	HMDB0000732	C10H12N2O4	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-17	Indoxyl sulfate	indoxyl_sulfate	HMDB0000682	C8H7NO4S	[M+Na]+	[M-H]-	50	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-17	alpha-Lactose	lactose	HMDB0000186	C12H22O11	[M+Na]+	[M+CHO2]-	194	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-17	7-Methylxanthine	methylxanthine_7	HMDB0001991	C6H6N4O2	[M+H]+	[M-H]-	85	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium
-17	Nicotine	nicotine	HMDB0001934	C10H14N2	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-17	Oxalacetic acid	oxalacetic	HMDB0000223	C4H4O5	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-17	Phosphoribosyl pyrophosphate	phosphoribosyl_pyrophosphate	HMDB0000280	C5H13O14P3	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad
-17	Ribose 5-Phosphate	ribose_phosphate	HMDB0001548	C5H11O8P	[M+H-H2O]+	[M-H]-	230	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-17	Succinylacetone	succinylacetone	HMDB0000635	C7H10O4	[M+Na]+	[M-H]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-17	UTP	UTP	HMDB0000285	C9H15N2O15P3	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-17	Xanthosine	xanthosine	HMDB0000299	C10H12N4O6	[M+Na]+	[M-H]-	153	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect
-18	Fructose 6-Phosphate	fructose_phosphate	HMDB0000124	C6H13O9P	[2M+H]+	[2M-H]-	235	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good
-18	2-Hydroxybutyric acid	hydroxybutyric_2	HMDB0000008	C4H8O3	NA	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium
-18	3-Hydroxy-DL-kynurenine	hydroxykynurenine_3	HMDB0000732	C10H12N2O4	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-18	Succinyl-CoA	succinyl_CoA	HMDB0001022	C25H40N7O19P3S	NA	NA	227	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad
-19	Adenine	adenine	HMDB0000034	C5H5N5	[M+H]+	[M-H]-	133	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-19	ATP	ATP	HMDB0000538	C10H16N5O13P3	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-19	Homocysteinethiolactone	homocysteinethiolactone	HMDB0002287	C4H7NOS	[M+H]+	NA	124	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-19	Methylamine	methylamine	HMDB0000164	CH5N	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-19	Trimethylamine	trimethylamine	HMDB0000906	C3H9N	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad
-19	UMP	UMP	HMDB0000288	C9H13N2O9P	[M+H]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good
-20	7-Aminoheptanoic acid	aminoheptanoic	HMDB0033826	C15H24O	NA	NA	28	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad
-20	3-Chloro-5-(trifluoromethyl)-2-pyrindol	chlorotrifluoromethylpyrindol	NA	C6H3ClF3NO	[M+H]+	[M-H]-	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-20	"3,5-Dichloro-2-hydroxypyridine"	dichlorohydroxypyridine	NA	C5H3Cl2NO	[M+H]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
-20	"3,5,6-Trichloro-2-pyrinidol"	trichloropyrinidol	NA	C5H2Cl3NO	[M+H]+	[M-H]-	32	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect
+mix	name	abbreviation	HMDB.code	formula	POS	NEG	RT	data_set	sample	operator	version	quality_POS	quality_NEG	note
+1	Acetylhistidine	acetylhistidine	HMDB0032055	C8H11N3O3	[M+H]+	[M-H]-	180	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+1	Betaine	betaine	HMDB0000043	C5H11NO2	[M+H]+	[M+CHO2]-	166	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+1	C3 Carnitine	carnitine_c3	HMDB0000824	C10H19NO4	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+1	CDP	CDP	HMDB0001546	C9H15N3O11P2	NA	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+1	Creatine	creatine	HMDB0000064	C4H9N3O2	[M+H]+	[M-H]-	173	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+1	Dimethylglycine	dimethylglycine	HMDB0000092	C4H9NO2	[M+H]+	[M-H]-	177	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+1	L-Glutamic Acid	glutamic	HMDB0000148	C5H9NO4	[M+H]+	[M-H]-	176	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+1	Glycerol	glycerol	HMDB0000131	C3H8O3	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad	
+1	Myo-Inositol	myoinositol	HMDB0000211	C6H12O6	[M+Na]+	[M+CHO2]-	193	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+1	3-Phosphoglyceric Acid	phosphoglyceric_3	HMDB0000807	C3H7O7P	[M+H]+	[M-H]-	267	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+1	propionic acid	propionic	HMDB0000237	C3H6O2	NA	[M-H]-	53	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+1	Pyruvic Acid	pyruvic	HMDB0000243	C3H4O3	NA	[M-H]-	41	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+1	Suberic Acid	suberic	HMDB0000893	C8H14O4	[M+Na]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+1	Uric acid	uric	HMDB0000289	C5H4N4O3	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad	
+1	Xanthine	xanthine	HMDB0000292	C5H4N4O2	[M+H]+	[M-H]-	140	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+2	Ascorbic Acid	ascorbic	HMDB0000044	C6H8O6	[M+H]+	[M-H]-	128	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+2	C4 Carnitine	carnitine_c4	HMDB0000736	C11H21NO4	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	Sigma Aldrich 51085 (Isobutyryl-L-carnitine); chemical formula is of Butyrylcarnitine
+2	Fructose	fructose	HMDB0000660	C6H12O6	[M+Na]+	[M-H]-	150	2020_01_matrix_effect	serum	Vinicius	2	2_medium	2_medium	
+2	Glycine	glycine	HMDB0000123	C2H5NO2	[M+H]+	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+2	cGMP	GMP_c	HMDB0001314	C10H12N5O7P	[M+H]+	[M-H]-	217	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+2	Histidine	histidine	HMDB0000177	C6H9N3O2	[M+H]+	[M-H]-	188	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+2	Hydroxyproline	hydroxyproline	HMDB0000725	C5H9NO3	[M+H]+	[M-H]-	175	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+2	Hypoxanthine	hypoxanthine	HMDB0000157	C5H4N4O	[M+H]+	[M-H]-	126	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+2	L-Kynurenine	kynurenine	HMDB0000684	C10H12N2O3	[M+H]+	[M-H]-	157	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+2	Lactic acid	lactic	HMDB0000190	C3H6O3	NA	[M-H]-	38	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+2	1-Methylxanthine	methylxanthine_1	HMDB0010738	C6H6N4O2	[M+H]+	[M-H]-	80	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+2	3-Nitrotyrosine	nitrotyrosine	HMDB0001904	C9H10N2O5	[M+H]+	[M-H]-	157	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+2	Phosphocreatine	phosphocreatine	HMDB0001511	C4H10N3O5P	[M+H]+	[M-H]-	198	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+2	UDP-glucuronate	UDP_glucuronate	HMDB0000935	C15H22N2O18P2	[M+NH4]+	[M-H]-	323	2020_01_matrix_effect	water	Vinicius	2	3_bad	3_bad	
+2	Valine	valine	HMDB0000883	C5H11NO2	[M+H]+	[M-H]-	166	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+3	Acetyl-CoA	acetylcoa	HMDB0001206	C23H38N7O17P3S	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+3	Adenylosuccinic Acid	adenylosuccinic	HMDB0000536	C14H18N5O11P	[M+H]+	[M-H]-	250	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+3	Alanine	alanine	HMDB0000161	C3H7NO2	[M+H]+	[M-H+HCOONa]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+3	Citrulline	citrulline	HMDB0000904	C6H13N3O3	[M+H]+	[M-H]-	182	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+3	Cytosine	cytosine	HMDB0000630	C4H5N3O	[M+H]+	[M-H]-	153	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+3	Glucose	glucose	HMDB0000122	C6H12O6	[M+Na]+	[M+CHO2]-	167	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+3	Glutathione Oxidized	glutathione_oxidized	HMDB0003337	C20H32N6O12S2	[M+H]+	[M-H]-	212	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+3	Glycolic acid	glycolic	HMDB0000115	C2H4O3	NA	[M-H]-	49	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+3	Guanine	guanine	HMDB0000132	C5H5N5O	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+3	Isoleucine	isoleucine	HMDB0000172	C6H13NO2	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+3	Malonic acid	malonic	HMDB0000691	C3H4O4	NA	[M-H]-	63	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+3	Niacinamide	niacinamide	HMDB0001406	C6H6N2O	[M+H]+	NA	50	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+3	5-Oxoproline	oxoproline	HMDB0000267	C5H7NO3	[M+H]+	[M-H]-	71	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+3	Palmitoylcarnitine	palmitoylcarnitine	HMDB0000222	C23H45NO4	[M+H]+	[M+CHO2]-	34	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	2_medium	3_bad	
+3	UDP	UDP	HMDB0000295	C9H14N2O12P2	NA	NA	238	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+4	Acetylalanine	acetylalanine_NL	HMDB0000766	C5H9NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+4	Allantoin	allantoin	HMDB0000462	C4H6N4O3	[M+H]+	[M-H]-	139	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+4	Gamma-Aminobutyric acid	aminobutyric	HMDB0000112	C4H9NO2	[M+H]+	NA	144	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+4	AMP	AMP	HMDB0000045	C10H14N5O7P	[M+H]+	[2M-H]-	212	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good	
+4	Glutamine	glutamine	HMDB0000641	C5H10N2O3	[M+H]+	[M-H]-	178	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+4	GMP	GMP	HMDB0001397	C10H14N5O8P	[M+H]+	[M-H]-	229	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+4	Leucine	leucine	HMDB0000687	C6H13NO2	[M+H]+	[M-H]-	152	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+4	Phenylethylamine	phenylethylamine	HMDB0012275	C8H11N	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+4	Propylene glycol	propylene_glycol	HMDB0001881	C3H8O2	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+4	Putrescine	putrescine	HMDB0001414	C4H12N2	[M+H-NH3]+	NA	173	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+4	Pyridoxine	pyridoxine	HMDB0000239	C8H11NO3	[M+H]+	[M-H]-	123	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+4	Riboflavin	riboflavin	HMDB0000244	C17H20N4O6	[M+H]+	[M-H]-	145	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+4	Ribose	ribose	HMDB0000283	C5H10O5	NA	[M-H]-	100	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+4	SAMe	SAMe	HMDB0001185	C15H23N6O5S	[M+H]+	NA	193	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	3_bad	
+4	Sedoheptulose-7-phosphate	sedoheptulose_phosphate	HMDB0001068	C7H15O10P	[M+H-H2O]+	[2M-H]-	235	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+5	dADP	ADP_d	HMDB0001508	C10H15N5O9P2	[M+H]+	[M-H]-	260	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+5	dCDP	CDP_d	HMDB0001245	C9H15N3O10P2	[M+H]+	[M-H]-	260	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+5	CoA	CoA	HMDB0001423	C21H36N7O16P3S	NA	[M-H]-	203	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+5	Corticosterone	corticosterone	HMDB0001547	C21H30O4	[M+H]+	[M+CHO2]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	3_bad	
+5	"1,3-Dimethyluric acid"	dimethyluric_1_3	HMDB0001857	C7H8N4O3	[M+H]+	[M-H]-	100	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+5	Glycerophospho-inositol	glycerophospho_inositol	HMDB0011649	C9H19O11P	[M+H]+	[M-H]-	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	NA	NA	
+5	GTP	GTP	HMDB0001273	C10H16N5O14P3	NA	[M-H]-	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+5	2-Ketobutyric acid	ketobutyric_2	HMDB0000005	C4H6O3	NA	[M-H]-	39	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+5	Mannose	mannose	HMDB0000169	C6H12O6	[M+Na]+	[M+CHO2]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+5	5-MTA	MTA	HMDB0001173	C11H15N5O3S	[M+H]+	[M+CHO2]-	80	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+5	NADP	NADP	HMDB0000217	C21H28N7O17P3	[M+H]+	[M-H]-	280	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+5	Nicotinic acid	nicotinic	HMDB0001488	C6H5NO2	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+5	Orotic acid	orotic	HMDB0000226	C5H4N2O4	[M+H]+	[M-H]-	177	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+5	PABA	PABA	HMDB0001392	C7H7NO2	[M+H]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	2_medium	
+5	Threonine	threonine	HMDB0000167	C4H9NO3	[M+H]+	[M-H]-	173	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+6	Acetylglutamic acid	acetylglutamic	HMDB0001138	C7H11NO5	[M+H]+	[M-H]-	87	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+6	Acetylglycine	acetylglycine	HMDB0000532	C4H7NO3	[M+H]+	[M-H]-	54	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+6	Arginine	arginine	HMDB0000517	C6H14N4O2	[M+H]+	[M-H]-	187	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good	
+6	Asparagine	asparagine	HMDB0000168	C4H8N2O3	[M+H]+	[M-H]-	183	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+6	Choline	choline	HMDB0000097	C5H13NO	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+6	CMP	CMP	HMDB0000095	C9H14N3O8P	[M+H]+	[M-H]-	211	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+6	Cystine	cystine	HMDB0000192	C6H12N2O4S2	[M+H]+	[M-H]-	211	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+6	Histamine	histamine	HMDB0000870	C5H9N3	[M+H]+	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+6	3-Hydroxybutyric Acid	hydroxybutyric_3	HMDB0000357	C4H8O3	[M+Na]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect	
+6	Methioninesulfoxide	methionine_sulfoxide	HMDB0002005	C5H11NO3S	[M+H]+	[M-H]-	182	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+6	Paracetamol	paracetamol	HMDB0001859	C8H9NO2	[M+H]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+6	Sphingosine-1-phosphate	sphingosine_phosphate	HMDB0000277	C18H38NO5P	[M+H]+	[M-H]-	145	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+6	Sucrose	sucrose	HMDB0000258	C12H22O11	[M+Na]+	[M+CHO2]-	187	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+6	Tryptophan	tryptophan	HMDB0000929	C11H12N2O2	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+6	UDP-acetylglucosamine	UDP_acetylglucosamine	HMDB0000290	C17H27N3O17P2	[M+H]+	[M-H]-	331	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+7	ADMA	ADMA	HMDB0001539	C8H18N4O2	[M+H]+	[M-H]-	176	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	dAMP	AMP_d	HMDB0000905	C10H14N5O6P	[M+H]+	[M-H]-	208	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	Caffeine	caffeine	HMDB0001847	C8H10N4O2	[M+H]+	NA	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	3_bad	
+7	CDP-choline	CDP_choline	HMDB0001413	C14H26N4O11P2	[M+H]+	[M+CHO2]-	217	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	Creatinine	creatinine	HMDB0000562	C4H7N3O	[M+H]+	[M-H]-	87	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+7	Glutaric acid	glutaric	HMDB0000661	C5H8O4	NA	[M-H]-	38	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+7	Glycero-phosphocholine	glycero_phosphocholine	HMDB0000086	C8H20NO6P	[M+H]+	[M+Cl]-	189	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	Methionine	methionine	HMDB0000696	C5H11NO2S	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	3-Methylhistidine	methylhistidine_3	HMDB0000479	C7H11N3O2	[M+H]+	[M-H]-	186	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	1-Methyluric acid	methyluric	HMDB0003099	C6H6N4O3	[M+H]+	[M-H]-	145	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good	
+7	Phenylpyruvic acid	phenylpyruvic	HMDB0000205	C9H8O3	[M+H-H2O]+	[M-H]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+7	Serine	serine	HMDB0000187	C3H7NO3	[M+H]+	[M-H]-	181	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	Sphingosine	sphingosine	HMDB0000252	C18H37NO2	[M+H]+	[M+CHO2]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	3_bad	
+7	Taurine	taurine	HMDB0000251	C2H7NO3S	[M+H]+	[M-H]-	172	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+7	Threonic Acid	threonic	HMDB0000943	C4H8O5	[M+Na]+	[M-H]-	130	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+8	Aspirin	aspirin	HMDB0001879	C9H8O4	NA	[M-H]-	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+8	Biotin	biotin	HMDB0000030	C10H16N2O3S	[M+H]+	[M-H]-	72	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+8	C5 Carnitine	carnitine_c5	HMDB0000688	C12H23NO4	[M+H]+	NA	47	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+8	Cystathionine	cystathionine	HMDB0000099	C7H14N2O4S	[M+H]+	[M-H]-	207	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+8	"5,6-Dihydro Thymine"	dihydrothymine	HMDB0000079	C5H8N2O2	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+8	dGDP	GDP_d	HMDB0000960	C10H15N5O10P2	[M+H]+	[M-H]-	260	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+8	Glyceric Acid	glyceric	HMDB0000139	C3H6O4	NA	[M-H]-	75	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+8	Inosine	inosine	HMDB0000195	C10H12N4O5	[M+Na]+	[M-H]-	146	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+8	Mevalonic Acid	mevalonic	HMDB0000227	C6H12O4	[M+H-H2O]+	[M-H]-	48	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+8	NADPH	NADPH	HMDB0000221	C21H30N7O17P3	NA	NA	207	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+8	Norepinephrine	norepinephrine	HMDB0000216	C8H11NO3	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+8	Ornithine	ornithine	HMDB0000214	C5H12N2O2	[M+H]+	[M-H]-	190	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+8	Succinic Acid	succinic	HMDB0000254	C4H6O4	NA	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+8	Tyrosine	tyrosine	HMDB0000158	C9H11NO3	[M+H]+	[M-H]-	168	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+8	Uracil	uracil	HMDB0000300	C4H4N2O2	[M+H]+	[M-H]-	64	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+9	N-Acetylserine	acetylserine	HMDB0002931	C5H9NO4	[M+H]+	[M-H]-	82	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	ADP-Ribose	ADP_ribose	HMDB0001178	C15H23N5O14P2	[M+H]+	[M-H]-	270	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+9	CDP-ethanolamine	CDP_ethanolamine	HMDB0001564	C11H20N4O11P2	[M+H]+	[M-H]-	219	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+9	CTP	CTP	HMDB0000082	C9H16N3O14P3	NA	[M-H]-	232	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+9	L-Cysteine	cysteine	HMDB0000574	C3H7NO2S	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	Diethyl malonate	diethylmalonate	HMDB0029573	C7H12O4	[M+H]+	NA	29	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+9	Eplerone	eplerone	HMDB0014838	C24H30O6	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	NA	NA	
+9	Erythrose 4-phosphate	erythrose_phosphate	HMDB0001321	C4H9O7P	[M+Na]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+9	Glucose 1-Phosphate	glucose_phosphate_1	HMDB0000645	C6H13O9P	[2M+H]+	[2M-H]-	237	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	Guanosine	guanosine	HMDB0000133	C10H13N5O5	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+9	IMP	IMP	HMDB0000175	C10H13N4O8P	[M+H]+	[M-H]-	226	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	NADH	NADH	HMDB0001487	C21H29N7O14P2	[M+H]+	[M-H]-	265	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	Pipecolic acid	pipecolic	HMDB0000070	C6H11NO2	[M+H]+	[M-H]-	169	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	Proline	proline	HMDB0000162	C5H9NO2	[M+H]+	[M-H]-	169	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+9	Thymidine	thymidine	HMDB0000273	C10H14N2O5	[M+Na]+	[M-H]-	72	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+10	N-Acetylornithine	acetylornithine	HMDB0003357	C7H14N2O3	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+10	Adenosine	adenosine	HMDB0000050	C10H13N5O4	[M+H]+	[M+CHO2]-	134	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+10	L-Aspartic Acid	aspartic	HMDB0000191	C4H7NO4	[M+H]+	[M-H]-	181	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+10	Citric Acid	citric	HMDB0000094	C6H8O7	[M+Na]+	[M-H]-	177	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+10	Cytidine	cytidine	HMDB0000089	C9H13N3O5	[M+H]+	[M+CHO2]-	162	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+10	Fumaric Acid	fumaric	HMDB0000134	C4H4O4	NA	[M-H]-	48	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+10	GDP	GDP	HMDB0001201	C10H15N5O11P2	[M+H]+	[M-H]-	295	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+10	Glucosamine	glucosamine	HMDB0001514	C6H13NO5	[M+H]+	[M+CHO2]-	181	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+10	Phosphoenolpyruvic Acid	phosphoenolpyruvic	HMDB0000263	C3H5O6P	[M+H]+	[M-H]-	227	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+10	Phosphorylethanolamine	phosphorylethanolamine	HMDB0000224	C2H8NO4P	[M+H]+	[2M-H]-	198	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	1_good	
+10	Ribulose 5-Phosphate	ribulose_phosphate	HMDB0000618	C5H11O8P	[M+H]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+10	SAH	SAH	HMDB0000939	C14H20N6O5S	[M+H]+	[M-H]-	186	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+10	Salicylic acid	salicylic	HMDB0001895	C7H6O3	[M+H]+	[M-H]-	34	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	0_perfect	
+10	Spermidine	spermidine	HMDB0001257	C7H19N3	[M+H]+	NA	188	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+10	Thymine	thymine	HMDB0000262	C5H6N2O2	[M+H]+	[M-H]-	58	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+11	ADP	ADP	HMDB0001341	C10H15N5O10P2	[M+H]+	[M-H]-	256	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+11	L-Carnitine	carnitine	HMDB0000062	C7H15NO3	[M+H]+	NA	130	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+11	dCTP	CTP_d	HMDB0000998	C9H16N3O13P3	NA	[M-H]-	228	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+11	"L,L-Cyclo(leucylprolyl)"	cyclo_leucylprolyl	HMDB0034276	C11H18N2O2	[M+H]+	NA	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	3_bad	
+11	Dihydroorotic acid	dihydroorotic	HMDB0003349	C5H6N2O4	[M+H]+	[M-H]-	120	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+11	Glutathione Reduced	glutathione_reduced	HMDB0000125	C20H32N6O12S2	[M+H]+	[M-H]-	211	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+11	Alpha-ketoisovaleric acid	ketoisovaleric	HMDB0000019	C5H8O3	NA	[M-H]-	34	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+11	Lysine	lysine	HMDB0000182	C6H14N2O2	[M+H]+	[M-H]-	188	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+11	Malic Acid	malic	HMDB0000156	C4H6O5	NA	[M-H]-	92	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+11	3-Methylxanthine	methylxanthine_3	HMDB0001886	C6H6N4O2	[M+H]+	[M-H]-	86	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+11	2-Phosphoglyceric Acid	phosphoglyceric_2	HMDB0000362	C3H7O7P	[M+H]+	[M-H]-	250	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+11	SDMA	SDMA	HMDB0003334	C8H18N4O2	[M+H]+	[M-H]-	174	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+11	Tetrahydrobiopterin	tetrahydrobiopterin	HMDB0000027	C9H15N5O3	[M+Na]+	NA	141	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad	
+11	p-Tyramine	tyramine	HMDB0000306	C8H11NO	[M+H]+	NA	127	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+11	UDP-Glucose	UDP_glucose	HMDB0000286	C15H24N2O17P2	[M+Na]+	[M-H]-	305	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	2_medium	
+12	Argininosuccinic acid	argininosuccinic	HMDB0000052	C10H18N4O6	[M+H]+	[M-H]-	199	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+12	Carnosine	carnosine	HMDB0000033	C9H14N4O3	[M+H]+	[M-H]-	184	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+12	dCMP	CMP_d	HMDB0001202	C9H14N3O7P	[M+H]+	[2M-H]-	203	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+12	Folic acid	folic	HMDB0000121	C19H19N7O6	[M+Na]+	[M-H]-	160	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+12	N-Formyl-L-methionine	formylmethionine	HMDB0001015	C6H11NO3S	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+12	Galactitol	galactitol	HMDB0000107	C6H14O6	[M+Na]+	[M-H]-	167	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+12	Glucose 6-Phosphate	glucose_phosphate_6	HMDB0001401	C6H13O9P	[2M+H]+	[2M-H]-	239	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+12	dGMP	GMP_d	HMDB0001044	C10H14N5O7P	[M+H]+	[M-H]-	223	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+12	Guanidoacetic acid	guanidoacetic	HMDB0000128	C3H7N3O2	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+12	Homocysteine	homocysteine	HMDB0000742	C4H9NO2S	[M+H]+	[M-H]-	168	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+12	Ketoleucine	ketoleucine	HMDB0000695	C6H10O3	[M+H]+	[M-H]-	34	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+12	Methotrexate	methotrexate	HMDB0014703	C20H22N8O5	[M+H]+	[M-H]-	155	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+12	Sebacic acid	sebacic	HMDB0000792	C10H18O4	[M+Na]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+12	Thiamine	thiamine	HMDB0000235	C12H16N4OS	[M+H]+	[M-H]-	148	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+12	Tryptamine	tryptamine	HMDB0000303	C10H12N2	[M+H-NH3]+	NA	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+13	N-Acetyl-beta-alanine	acetylalanine_NB	HMDB0061880	C5H9NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+13	Acetylneuraminic Acid	acetylneuraminic	HMDB0000230	C11H19NO9	[M+H-H4O2]+	[M-H]-	180	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+13	Dopamine	dopamine	HMDB0000073	C8H11NO2	[M+H]+	[M-H]-	140	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+13	"Fructose-1,6-Diphosphate"	fructose_diphosphate	HMDB0001058	C6H14O12P2	[M+H-H2O]+	[M-H]-	330	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad	
+13	Ibuprofen	ibuprofen	HMDB0001925	C13H18O2	NA	[M-H]-	31	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect	
+13	Indoleacetic acid	indoleacetic	HMDB0000197	C10H9NO2	[M+H]+	[M-H]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+13	1-Methylhistidine	methylhistidine_1	HMDB0000001	C7H11N3O2	[M+H]+	[M-H]-	182	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+13	8-Oxo-2-Deoxyguanosine	oxodeoxyguanosine	HMDB0003333	C10H13N5O5	[M+H]+	[M-H]-	159	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+13	Pantothenic Acid	pantothenic	HMDB0000210	C9H17NO5	[M+H]+	[M-H]-	38	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+13	Phenylacetic acid	phenylacetic	HMDB0000209	C8H8O2	[M+H]+	[M-H]-	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+13	Phosphorylcholine	phosphorylcholine	HMDB0001565	C5H14NO4P	[M+H]+	[M+Cl]-	195	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+13	Sorbitol	sorbitol	HMDB0000247	C6H14O6	[M+Na]+	[M-H]-	165	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+13	Spermine	spermine	HMDB0001256	C10H26N4	[M+H]+	NA	204	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+13	Uridine	uridine	HMDB0000296	C9H12N2O6	[M+H]+	[M+CHO2]-	124	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+13	dUTP	UTP_d	HMDB0001191	C9H15N2O14P3	NA	NA	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+14	Acetylcarnitine	acetylcarnitine	HMDB0000201	C9H17NO4	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+14	ADP-Glucose	ADP_glucose	HMDB0006557	C16H25N5O15P2	[M+H-Hexose-H2O]+	[M-H]-	275	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+14	"1,5-anhydro D-glucitol"	anhydroglucitol	HMDB0002712	C6H12O5	[M+Na]+	[M+CHO2]-	135	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+14	Glyceraldehyde 2-phosphate	glyceraldehyde_phosphate	HMDB0001112	C3H7O6P	[M+H]+	[M-H]-	213	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+14	Glycerol-3-Phosphate	glycerol_phosphate	HMDB0000126	C3H9O6P	[M+H]+	[2M-H]-	222	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+14	dGTP	GTP_d	HMDB0001440	C10H16N5O13P3	NA	NA	233	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+14	Indolelactic acid	indolelactic	HMDB0000671	C11H11NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+14	Isocitric Acid	isocitric	HMDB0000193	C6H8O7	NA	[M-H]-	146	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+14	2-Ketoglutaric acid	ketoglutaric_2	HMDB0000208	C5H6O5	NA	[M-H]-	75	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+14	Levodopa	levodopa	HMDB0000181	C9H11NO4	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+14	NAD	NAD	HMDB0000902	C21H27N7O14P2	[M+H]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+14	Pyridoxic Acid	pyridoxic	HMDB0000017	C8H9NO4	[M+H]+	[M-H]-	85	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+14	Serotonin	serotonin	HMDB0000259	C10H12N2O	[M+H-NH3]+	[M+Cl]-	132	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+14	Ureidopropionic acid	ureidopropionic	HMDB0000026	C4H8N2O3	[M+H]+	[M-H]-	88	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+14	Xylulose 5-Phosphate	xylulose_phosphate	HMDB0000868	C5H11O8P	[M+H]+	[2M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+15	N-alpha-Acetyl-L-arginine	acetylarginine	HMDB0004620	C8H16N4O3	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+15	alpha-Aminoadipic acid	aminoadipic	HMDB0000510	C6H11NO4	[M+H]+	[M-H]-	170	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+15	FAD	FAD	HMDB0001248	C27H33N9O15P2	[M+H]+	[M-H]-	290	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+15	Glucosamine-6-Phosphate	glucosamine_phosphate	HMDB0001254	C6H14NO8P	[M+H]+	[2M-H]-	219	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+15	Glucuronic Acid	glucuronic	HMDB0000127	C6H10O7	[M+Na]+	[M-H]-	171	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect	
+15	p-Hydroxyphenylacetic acid	hydroxyphenylacetic	HMDB0000020	C8H8O3	[M+H-H2O]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+15	Isovalerylglycine	isovalerylglycine	HMDB0000678	C7H13NO3	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+15	2-Methylcitric acid	methylcitric	HMDB0000379	C7H10O7	[M+Na]+	[M-H]-	171	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+15	Phenylalanine	phenylalanine	HMDB0000159	C9H11NO2	[M+H]+	[M-H]-	154	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+15	Phosphoserine	phosphoserine	HMDB0000272	C3H8NO6P	[M+H]+	[2M-H]-	231	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+16	Acetyl-Glucosamine	acetylglucosamine	HMDB0000215	C8H15NO6	[M+Na]+	[M+CHO2]-	156	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+16	Acetylmethionine	acetylmethionine	HMDB0011745	C7H13NO3S	[M+H]+	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+16	Dihydroxyacetone phosphate	dihydroxyacetone_phosphate	HMDB0001473	C3H7O6P	[M+H]+	[2M-H]-	220	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+16	"1,7-Dimethyluric acid"	dimethyluric_1_7	HMDB0011103	C7H8N4O3	[M+H]+	[M-H]-	119	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+16	homovanillic acid	homovanillic	HMDB0000118	C9H10O4	[M+H-CH2O2]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	0_perfect	
+16	6-Phosphogluconic Acid	phosphogluconic	HMDB0001316	C6H13O10P	[M+H-H2O]+	[M-H]-	265	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+16	Quinolinic acid	quinolinic	HMDB0000232	C7H5NO4	[M+H]+	[M-H]-	176	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+17	Acetylaspartic acid	acetylaspartic	HMDB0000812	C6H9NO5	[M+H]+	[M-H]-	100	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	1_good	
+17	dATP	ATP_d	HMDB0001532	C10H16N5O12P3	NA	[M-H]-	224	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+17	Epinephrine	epinephrine	HMDB0000068	C9H13NO3	[M+H]+	[M-H]-	144	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+17	Gluconic Acid	gluconic	HMDB0000625	C6H12O7	[M+Na]+	[M-H]-	171	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	2_medium	
+17	3-Hydroxy-DL-kynurenine	hydroxykynurenine_3	HMDB0000732	C10H12N2O4	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+17	Indoxyl sulfate	indoxyl_sulfate	HMDB0000682	C8H7NO4S	[M+Na]+	[M-H]-	50	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+17	alpha-Lactose	lactose	HMDB0000186	C12H22O11	[M+Na]+	[M+CHO2]-	194	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+17	7-Methylxanthine	methylxanthine_7	HMDB0001991	C6H6N4O2	[M+H]+	[M-H]-	85	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	2_medium	
+17	Nicotine	nicotine	HMDB0001934	C10H14N2	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+17	Oxalacetic acid	oxalacetic	HMDB0000223	C4H4O5	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+17	Phosphoribosyl pyrophosphate	phosphoribosyl_pyrophosphate	HMDB0000280	C5H13O14P3	NA	NA	NA	2020_01_matrix_effect	serum	Vinicius	2	3_bad	3_bad	
+17	Ribose 5-Phosphate	ribose_phosphate	HMDB0001548	C5H11O8P	[M+H-H2O]+	[M-H]-	230	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+17	Succinylacetone	succinylacetone	HMDB0000635	C7H10O4	[M+Na]+	[M-H]-	35	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+17	UTP	UTP	HMDB0000285	C9H15N2O15P3	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+17	Xanthosine	xanthosine	HMDB0000299	C10H12N4O6	[M+Na]+	[M-H]-	153	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	0_perfect	
+18	Fructose 6-Phosphate	fructose_phosphate	HMDB0000124	C6H13O9P	[2M+H]+	[2M-H]-	235	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	1_good	
+18	2-Hydroxybutyric acid	hydroxybutyric_2	HMDB0000008	C4H8O3	NA	[M-H]-	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	2_medium	
+18	3-Hydroxy-DL-kynurenine	hydroxykynurenine_3	HMDB0000732	C10H12N2O4	[M+H]+	[M-H]-	163	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+18	Succinyl-CoA	succinyl_CoA	HMDB0001022	C25H40N7O19P3S	NA	NA	227	2020_01_matrix_effect	water	Mar Garcia-Aloy	2	3_bad	3_bad	
+19	Adenine	adenine	HMDB0000034	C5H5N5	[M+H]+	[M-H]-	133	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+19	ATP	ATP	HMDB0000538	C10H16N5O13P3	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+19	Homocysteinethiolactone	homocysteinethiolactone	HMDB0002287	C4H7NOS	[M+H]+	NA	124	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+19	Methylamine	methylamine	HMDB0000164	CH5N	NA	NA	NA	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+19	Trimethylamine	trimethylamine	HMDB0000906	C3H9N	[M+H]+	NA	37	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	2_medium	3_bad	
+19	UMP	UMP	HMDB0000288	C9H13N2O9P	[M+H]+	[M-H]-	225	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	1_good	1_good	
+20	7-Aminoheptanoic acid	aminoheptanoic	HMDB0033826	C15H24O	NA	NA	28	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	3_bad	3_bad	
+20	3-Chloro-5-(trifluoromethyl)-2-pyrindol	chlorotrifluoromethylpyrindol	NA	C6H3ClF3NO	[M+H]+	[M-H]-	33	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+20	"3,5-Dichloro-2-hydroxypyridine"	dichlorohydroxypyridine	NA	C5H3Cl2NO	[M+H]+	[M-H]-	36	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	
+20	"3,5,6-Trichloro-2-pyrinidol"	trichloropyrinidol	NA	C5H2Cl3NO	[M+H]+	[M-H]-	32	2020_01_matrix_effect	serum	Mar Garcia-Aloy	2	0_perfect	0_perfect	

--- a/match-standards-serum-mix01.Rmd
+++ b/match-standards-serum-mix01.Rmd
@@ -16,6 +16,9 @@ knitr::read_chunk("R/match-standards-chunks.R")
 MIX <- 1
 MATRIX <- "Serum"
 POLARITY <- "POS"
+## settings to find MS2 spectra for features. Be rather inclusive here.
+FEATURE_MS2_PPM <- 20
+FEATURE_MS2_TOLERANCE <- 0.05
 ```
 
 ```{r, libraries, echo = FALSE, message = FALSE}
@@ -103,7 +106,7 @@ Standards for which no MS2 spectrum in HMDB is present are listed in
 the table below.
 
 ```{r, echo = FALSE, results = "asis"}
-tmp <- std_dilution01[!(std_dilution01$HMDB %in% hmdb_std$compound_id), ]
+tmp <- std_dilution[!(std_dilution$HMDB %in% hmdb_std$compound_id), ]
 pandoc.table(tmp[, c("name", "HMDB", "formula")], style = "rmarkdown",
              caption = "Standards for which no reference spectrum is available")
 ```
@@ -191,7 +194,7 @@ removed.
 ```
 
 For most of the standards (`r length(unique(mD$target_name))` out of 
-`r nrow(std_dilution01)`) in mix `r MIX` at least one feature was found
+`r nrow(std_dilution)`) in mix `r MIX` at least one feature was found
 matching the standards adducts' m/z. 
 
 ```{r, table-standard-no-feature, results = "asis", echo = FALSE}
@@ -965,7 +968,15 @@ std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 ```
 
-The spectrum does thus not match any reference spectra from `r std`. In addition
+One of the spectra matches the reference with a low similarity. Below we plot
+this.
+
+```{r mix01-water-pos-dimethylglycine-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.3, ppm = csp@ppm,
+                               tolerance = csp@tolerance)
+```
+
+In addition
 we compare it aginst the reference spectra from MassBank for the selected
 standard.
 
@@ -974,7 +985,7 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-Again, we don't obtain any match. Since the extracted spectrum is associated to
+We don't obtain any better match. Since the extracted spectrum is associated to
 an ion different from `[M+H]+` (`[M+2Na-H]+`) we also perform a comparison
 between the neutral loss spectra from HMDB and MassBank.
 
@@ -990,7 +1001,7 @@ std_ms2_nl <- neutralLoss(std_ms2, nl_param)
 sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
 ```
 
-We don't get any match.
+We get the same matches, but with higher similarity.
 
 In addition we match (**all**) the MS2 spectra for the
 matched features against all spectra from HMDB or MassBank identifying reference
@@ -1025,16 +1036,18 @@ strangely matches a lot of other reference compounds.
 
 #### Summary
 
-- FT01184 (RT = 174.6, `[M+2Na-H]+` ion): confidence level **D**.
-- FT00753 (RT = 175, `[M+Na]+` ion): confidence level **D**.
-- FT00428 (RT = 178.6, `[M+H]+` ion): confidence level **D**.
+- FT00428 (RT = 178.6, `[M+H]+` ion): confidence level **C**.
+- FT01184 (RT = 174.6, `[M+2Na-H]+` ion): confidence level **C-**.
+- FT00753 (RT = 175, `[M+Na]+` ion): confidence level **C-**.
+- Reference MS2: `[M+H]+`: FT00428_F08.S0693; low confidence. `[M+2Na-H]+`:
+  FT01184_F08.S0617; low confidence.
 
 ```{r, echo = FALSE}
 ## Define the feature (ion) and MS2 spectra to insert
 fts <- data.frame(feature_id = c("FT00428"),
-                  confidence_level = c("D"))
+                  confidence_level = c("C"))
 ## Get MS2 spectra:
-ms2 <- std_ms2[c("FT01184_F08.S0617")]
+ms2 <- std_ms2[c("FT01184_F08.S0617", "FT00428_F08.S0693")]
 ms2$confidence <- "low"
 ```
 
@@ -1657,11 +1670,41 @@ We next plot the EIC for the assigned feature and visually inspect these.
 plot_eics(data, std, feature_table, "SP", std_ms2)
 ```
 
-Signal is very low for all of the features. And also no MS2 spectra were
-found.
+Signal is very low for all of the features. 
 
-```{r , echo = FALSE}
+
+```{r mix01-serum-pos-uric-acid-ms2, echo = FALSE}
 plot_spectra(std_ms2)
+```
+
+```{r mix01-serum-pos-uric-acid-ms2-hmdb-heatmap, fig.cap = "Similarities of MS2 spectra for selected features against reference spectra for uric acid from HMDB.", echo = FALSE, fig.width = 5, fig.height = 5}
+hmdb_id <- std_dilution$HMDB[std_dilution$name == std]
+std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
+```
+
+The spectra don't match. We repeat the comparison using MassBank reference
+spectra and we obtain similar results as shown below.
+
+```{r mix01-water-pos-xanthine-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
+std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
+```
+
+In addition we match (**all**) the MS2 spectra for the matched features against
+all spectra from HMDB or MassBank identifying reference spectra with a
+similarity larger than 0.7. The results (if any spectra matched) are shown in
+the two following tables.
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+std_ms2_sel <- Spectra()
+perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
 ```
 
 
@@ -1714,7 +1757,7 @@ removed.
 ```
 
 For most of the standards (`r length(unique(mD$target_name))` out of 
-`r nrow(std_dilution01)`) in mix `r MIX` at least one feature was found
+`r nrow(std_dilution)`) in mix `r MIX` at least one feature was found
 matching the standards adducts' m/z. 
 
 ```{r, table-standard-no-feature, results = "asis", echo = FALSE}

--- a/match-standards-serum-mix02.Rmd
+++ b/match-standards-serum-mix02.Rmd
@@ -15,6 +15,9 @@ knitr::read_chunk("R/match-standards-chunks.R")
 MIX <- 2
 MATRIX <- "Serum"
 POLARITY <- "POS"
+## settings to find MS2 spectra for features. Be rather inclusive here.
+FEATURE_MS2_PPM <- 20
+FEATURE_MS2_TOLERANCE <- 0.05
 ```
 
 ```{r, libraries, echo = FALSE, message = FALSE}
@@ -247,11 +250,12 @@ hmdb_id <- std_dilution$HMDB[std_dilution$name == std]
 std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 ```
-Spectra F07.S0389 from FT01572 matches reference spectra from `r std` with
-similarity score around 0.6.
+
+Spectra F07.S0389 from FT01572 and F07.S0398 and F08.S0394 from FT01902 match
+reference spectra from `r std`, the latter two with a lower score.
 
 ```{r mix02-serum-pos-ascorbic-acid-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.6, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.4, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -260,29 +264,7 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-In both cases we don't find any match. In addition, since all the extracted
-spectra are associated to ions different from `[M+H]+` we perform a neutral
-loss spectra comparison.
-
-```{r mix02-serum-pos-ascorbic-acid-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-ascorbic-acid-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-feature_table_sel <- plot_select_ms2(std_ms2_nl, std_hmdb_nl, 0.05,
-                           ppm = csp@ppm, tolerance = csp@tolerance)
-```
-
-```{r mix02-serum-pos-ascorbic-acid-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-For the HMDB comparison we don't find good matches while for the MassBank one
-the neutral loss spectra cannot be computed. 
+No match was found for reference spectra from MassBank.
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -315,12 +297,13 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT01572 (RT = 127.5, `[M+H-H2O]+` ion) with confidence level **C**? Reference
-spectrum F07.S0389?
-- FT03383 (RT = 127.5, `[M+2K-H]+` ion) in the same feature group as FT01572.
-  The associated spectra however don't match reference spectra from `r std`.
-- FT01902 (RT = 128.8, `[M+H]+` ion) same confidence level as FT01572 (in the
-  same feature group).
+- FT01902 (RT = 128.8, `[M+H]+` ion) confidence level **C**.
+- FT01572 (RT = 127.5, `[M+H-H2O]+` ion) with confidence level **C**.
+- FT03383 (RT = 127.5, `[M+2K-H]+` ion) confidence level **C**.
+- Reference MS2: `[M+H]+`: FT01572_F07.S0389; low confidence. `[M+H-H2O]+`:
+  FT01572_F08.S0393, FT01572_F07.S0389; low confidence. `[M+2K-H]+`:
+  FT03383_F07.S0390, FT03383_F07.S0428, FT03383_F08.S0387; low confidence.
+
 
 ### C4 Carnitine
 
@@ -418,9 +401,15 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-Many MS2 spectra can be extracted but none of them matches reference spectra
-from `r std` (like in the water case). They seem to match reference spectra from
-other compounds.
+- Inconclusive. Same as with water. MS2 spectra match butyrylcarnitine, not C4
+  carnitine. Maybe need to check back with Vinicius which standard was actually
+  bought and how the formula was defined (as it is the one of
+  butyrylcarnitine!).
+- FT02888 (RT = 37, `[M+H+]` ion) confidence level **D**? or **A** for
+  butyrylcarnitine.
+- FT03406 (RT = 36.46, `[M+Na]+` ion).
+- FT03708 (RT = 36.31, `[M+K]+` ion).
+  
 
 ### Fructose
 
@@ -519,7 +508,11 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-The available MS2 spectra do not match any reference spectra from `r std`.
+- FT02330 (RT = 150.7, `[M+Na]+` ion) confidence level **D**.
+- FT02615 (RT = 147.2, `[M+K]+` ion) confidence level **D**.
+- Reference MS2: `[M+Na]+`: FT02330_F08.S0476; low confidence. `[M+K]+`:
+  FT02615_F07.S0456; low confidence.
+
 
 ### Glycine
 
@@ -558,13 +551,16 @@ st2_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
                            ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
+Only the precursor peak matches, but the reference spectra have only a single
+peak (i.e. the precursor peak).
+
 ```{r mix02-serum-pos-glycine-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
 std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
 ```{r mix02-serum-pos-glycine-mirror-mbank, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.1,
+tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.7,
                            ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
@@ -589,8 +585,9 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-- FT00174 (RT = 173.1, `[M+H]+` ion) with confidence **A**. MS2 spectrum : 
-  F07.S0587.
+- FT00174 (RT = 173.1, `[M+H]+` ion) with confidence **A**. 
+- Reference MS2: `[M+H]+`: FT00174_F07.S0587; high confidence.
+  
   
 ### cGMP
 
@@ -627,12 +624,13 @@ hmdb_id <- std_dilution$HMDB[std_dilution$name == std]
 std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 ```
+
 The MS2 spectra from FT05702 match with high similarity score reference spectra
 from `r std`. We also have matches with very low similarity involving spectra
 from FT06569.
 
 ```{r mix02-serum-pos-cgmp-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.9, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -646,25 +644,6 @@ We observe similar results also from the MassBank comparison.
 tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
-
-The extracted spectra from feature FT4591 (F08.S0747, F07.S0735 and
-especially F07.S0777) seem to match reference spectra from `r std`. Also
-F08.S0748 from FT4903 matches but with very low similarity. 
-
-```{r mix02-serum-pos-cgmp-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-cgmp-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-With neutral loss comparison besides matches involving spectra from FT05702 we
-find a match involving F08.S0782 from feature FT06194. 
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -697,11 +676,13 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT05702 (RT = 216, ion `[M+H]+`): confidence **B**. MS2 spectra: F07.S0757,
-  F07.S0775, F07.S0796, F08.S0766, F08.S0788, F08.S0808.  
-- FT06194 (RT = 214.1, ion `[M+Na]+`): confidence **B**. MS2 spectrum: F08.S0782
-- FT06570 (RT = 218.1, ion `[M+K]+`): confidence **B**.
-- (FT06569 (RT = 211, ion `[M+K]+`): confidence **C**?)
+- FT05702 (RT = 216, `[M+H]+` ion): confidence **A**.
+- FT06194 (RT = 214.1, ion `[M+Na]+`): confidence **A-**.
+- FT06570 (RT = 218.1, ion `[M+K]+`): confidence **A-**.
+- Reference MS2: `[M+H]+`: FT05702_F07.S0757, FT05702_F07.S0775,
+  FT05702_F07.S0796, FT05702_F08.S0766, FT05702_F08.S0788, FT05702_F08.S0808;
+  high confidence. `[M+Na]+`: FT06194_F08.S0782; low confidence.
+  
 
 ### Histidine
 
@@ -753,31 +734,6 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-We obtain similar results with the MassBank comparison. In addition, since the
-extracted spectra from FT01102 that did not match are associated to ions
-different from `[M+H]+` we perform a neutral loss spectra comparison.
-
-```{r mix02-serum-pos-histidine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-sp<- c("FT01102_F07.S0387", "FT01102_F08.S0392")
-std_ms2_nl <- neutralLoss(std_ms2[sp], nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-histidine-mirror-hmdb_nl, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2_nl, std_hmdb_nl, 0.15,
-                           ppm = csp@ppm, tolerance = csp@tolerance)
-```
-
-```{r mix02-serum-pos-histidine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2[sp], nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-We don't get new good matches from the neutral loss spectra comparison but quite
-low similarity ones.
-
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
@@ -809,24 +765,14 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- 
-We have matches for four features with same ion but different retention times?
-- FT01452 (RT = 189.4, `[M+H]+` ion) confidence level **B** (also reference
-  spectra of compounds different from `r std` match with similarity higher
-  than 0.7). Reference spectra: F07.S0670, F07.S0729, F08.S0695?
-or
-- FT01455 (RT = 200, `[M+H]+` ion) confidence level **B**. Reference spectra: 
-  F07.S0729 (also assigned to previous feature)?
-or
-- FT01453 (RT = 211, `[M+H]+` ion) confidence level **B**. Reference spectra:
-  F07.S0729 (again), F07.S0763, F08.S0773?
-or
-- FT01456 (RT = 221.5, `[M+H]+` ion) confidence level **B**. Reference spectra:
-  F08.S0773 (also assigned to FT01453), F08.S0800?
+- FT01452 (RT = 189.4, `[M+H]+` ion) confidence level **A**. Other features for
+  that ion represent signal from the tail of this feature and are thus discarded
+  (along with their MS2 spectra).
+- FT01920 (RT = 189.1, `[M+Na]+` ion) confidence level **A-**.
+- FT02188 (RT = 185.3, `[M+K]+` ion) confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT01452_F07.S0670, FT01452_F07.S0729,
+  FT01452_F08.S0695; high confidence.
   
-In addition features inheriting confidence level from one of the features above
-for being in the same feature group.
-
   
 ### Hydroxyproline
 
@@ -868,7 +814,7 @@ The best matchings spectra are F07.S0648 and F08.S0686 from FT00922.
 Also F07.S0623 and F08.S0648 from FT00598 match (with similarity around 0.4).
  
 ```{r mix02-serum-pos-hydroxyproline-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.75,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
                                ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
@@ -876,24 +822,6 @@ std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.75,
 std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
-
-In addition, since spectra from FT00598 are associated to an ion different from
-`[M+H]+` we perform a neutral loss spectra comparison and we find new matches
-as shown below.
-
-```{r mix02-serum-pos-hydroxyproline-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-hydroxyproline-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-We don't find good matches neither with HMDB or MassBank comparison.
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -911,9 +839,6 @@ perform_match(std_ms2, mbank,
               name = "target_name", param = csp)
 ```
 
-There are matches with similarity higher than 0.7 involving more than one
-compound (maybe they are similar?).
-
 For completeness, we also perform a neutral loss spectra comparison with HMDB
 and MassBank.
 
@@ -921,6 +846,9 @@ and MassBank.
 perform_match(std_ms2_nl, hmdb_nl, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp_nl)
 ```
+
+Interestingly, some MS2 spectra associated with FT00922 match reference spectra
+from creatine.
 
 ```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
 perform_match(std_ms2_nl, mbank_nl,
@@ -930,9 +858,14 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT00922 (RT = 178, `[M+H]+`): confidence level **B**.
-- FT00598 (RT = 176, `[M+H-H2O]+`): confidence level **B**.
-- FT01418 (RT = 175.8, `[M+Na]+`): confidence level **B-**.
+- FT00922 (RT = 178, `[M+H]+`): confidence level **A**.
+- FT00598 (RT = 176, `[M+H-H2O]+`): confidence level **A-**.
+- FT01418 (RT = 175.8, `[M+Na]+`): confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT00922_F07.S0648, FT00922_F08.S0686; high
+  confidence. `[M+H-H2O]+`: FT00598_F07.S0623, FT00598_F08.S0648; low
+  confidence.
+  
+
 
 ### Hypoxanthine
 
@@ -975,7 +908,7 @@ FT01048. We have low similarity matches for F07.S0386 (around 0.25) and
 F08.S0390 (around 0.4) from FT00681.
  
 ```{r mix02-serum-pos-hypoxanthine-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -985,25 +918,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
 No good match is found with MassBank comparison (only low similarity ones
-for spectra from FT01048). In addition, since some of the extracted
-spectra are associated to ions different from `[M+H]+` we perform a neutral
-loss spectra comparison.
-
-```{r mix02-serum-pos-hypoxanthine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-hypoxanthine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-With neutral loss comparison we find new matches for spectrum
-F07.S0378 from FT01850 in the HMDB case (with similarity
-around 0.63).
+for spectra from FT01048).
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -1011,7 +926,6 @@ similarity larger than 0.7. The results (if any spectra matched) are shown in
 the two following tables.
 
 ```{r, echo = FALSE, message = FALSE, results = "asis"}
-std_ms2_sel <- Spectra()
 perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
@@ -1037,13 +951,20 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT01048 (RT = 127, ion `[M+H]+`): confidence level **B**. Reference spectra:
-  F07.S0377, F07.S0412, F08.S0381, F08.S0412.
-- FT01850 (RT = 125.9, ion `[M+K]+`): confidence level **B**. Reference spectra:
-  F07.S0378.
-- FT00681 (RT = 126.8, ion `[M+H-H2O]+`): confidence level **B-**. Reference
-  spectra: F08.S0390 and F07.S0386 (they don't match with high similarity).
+- FT01048 (RT = 127, `[M+H]+` ion): confidence level **A** (although the MS2
+  match also another compound with high confidence, but the precursor m/z
+  differs by 0.02).
+- FT01850 (RT = 125.9, `[M+K]+` ion): confidence level **A**.
+- FT00681 (RT = 126.8, `[M+H-H2O]+` ion): confidence level **A-**.
+- FT01572 (RT = 127.5, `[M+Na]+` ion): confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT01048_F07.S0377, FT01048_F07.S0412,
+  FT01048_F08.S0381, FT01048_F08.S0412; high confidence. `[M+K]+`:
+  FT01850_F07.S0378, FT01850_F08.S0382, FT01850_F08.S0414; low
+  confidence. `[M+H-H2O]+`: FT00681_F07.S0386, FT00681_F08.S0390; low
+  confidence. `[M+Na]+`: FT01572_F08.S0393, FT01572_F07.S0389; low confidence.
   
+
+
 ### L-Kynurenine
 
 ```{r, echo = FALSE}
@@ -1084,7 +1005,7 @@ We find matches with high similarity for extracted MS2 spectra from FT02454
 (F07.S0465 and F08.S0478).
 
 ```{r mix02-serum-pos-l-kynurenine-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -1094,25 +1015,6 @@ We repeat the same with MassBank obtaining similar results.
 std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
-
-Since we have MS2 spectra associated to ions different from `[M+H]+` we also
-perform a neutral loss comparison against reference spectra from HMDB and
-MassBank.
-
-```{r mix02-serum-pos-l-kynurenine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-l-kynurenine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-With this comparison we find new matches involving F07.S0469 and F08.S0482
-from FT03386 and a very low similarity one for F08.S0480 from FT02859.
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -1145,14 +1047,14 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT02454 (RT = 156.6, `[M+H]+` ion) with confidence level **B** or **A** (are
-  by any chance L-Kynurenine and D-Kynurenine the same?). Reference spectra:
-  F07.S0465 and F08.S0478.
-- FT03386 (RT = 157, `[M+2Na-H]+` ion) with confidence **B** or **A**. MS2
-  spectra: F07.S0469 and F08.S0482.
-- FT02859 (RT = 156.6, `[M+Na]+` ion) inherit confidence level from FT02454
-  because in the same feature group.
-- FT02158 (RT = 156.8, `[M+H-NH3]+` ion): same as above.
+- FT02454 (RT = 156.6, `[M+H]+` ion) with confidence level **A**.
+- FT03386 (RT = 157, `[M+2Na-H]+` ion) with confidence **A-**.
+- FT02859 (RT = 156.6, `[M+Na]+` ion) with confidence **A-**.
+- FT02158 (RT = 156.8, `[M+H-NH3]+` ion): with confidence **A-**.
+- Reference MS2: `[M+H]+`: FT02454_F07.S0465, FT02454_F08.S0478; high
+  confidence. `[M+Na]+`: FT02859_F08.S0480; low confidence. `[M+2Na-H]+`:
+  FT03386_F07.S0469, FT03386_F08.S0482; low confidence.
+
 
 ### Lactic acid
 
@@ -1162,10 +1064,6 @@ std <- "Lactic acid"
 
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
-
-Many features have been assigned to this standard based on
-m/z matching. Based on their retention times, these seem however to represent
-ions from different compounds.
 
 We next plot the EIC for the assigned feature and visually inspect these.
 
@@ -1183,7 +1081,8 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra, EICs maybe not very convincing.
+- Inconclusive. Low/no signal.
+
 
 ### 1-Methylxanthine
 
@@ -1234,24 +1133,6 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-In addition, since some of the extracted spectra are associated to ions
-different from `[M+H]+` we perform a neutral loss spectra comparison.
-
-```{r mix02-serum-pos-1-methylxanthine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-1-methylxanthine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-We obtain similar results with neutral loss comparison except a low
-similarity match for F08.S0285 from feature FT02478 (similarity around 0.2).
-
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
@@ -1283,18 +1164,15 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT01719 (RT = 80.6, `[M+H]+` ion) with confidence level **A**. Reference
-  spectra : F07.S0273 and F08.S0266.
-- FT02107 (RT = 81, `[M+Na]+` ion) in the same feature group as FT01719 but
-  the associated spectrum don't match.
-- FT02478 (RT = 80.8, `[M+2Na-H]+` ion) same as FT02107.
-
-- FT01720 (RT = 62, `[M+H]+` ion) with confidence level **A**. Associated
-  spectra: F07.S0197, F07.S0247, F08.S0196, 08.S0240, F08.S0266.
+- FT01719 (RT = 81.6, `[M+H]+` ion) with confidence level **A**.
+- FT02107 (RT = 81, `[M+Na]+` ion) with confidence level **A-**.
+- FT02478 (RT = 80.8, `[M+2Na-H]+` ion) with confidence level **A-**.
+- Tricky situation since also FT01720 (`[M+H]+` ion has MS2 matching the
+  standard, but the retention time is 60 seconds). Maybe add both?
+- Reference MS2: `[M+H]+`: FT01719_F07.S0273, FT01719_F08.S0266; high
+  confidence. `[M+Na]+`: FT02107_F08.S0273; low confidence. `[M+2Na-H]+`:
+  FT02478_F08.S0285; low confidence.
   
-For this last feature the retention time is not close to the RT found in
-previous analysis but spectra matches have a very high similarity score.
-
 
 ### 3-Nitrotyrosine
 
@@ -1343,22 +1221,6 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-In addition, since extracted spectrum F08.S0510 from FT03724 is associated to
-an ion different from `[M+H]+` we perform a neutral loss spectra comparison but
-still it does not match.
-
-```{r mix02-serum-pos-3-nitrotyrosine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-3-nitrotyrosine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
@@ -1390,11 +1252,11 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT02778 (RT=156.8, `[M+H]+` ion) with confidence level **B**. MS2 spectra:
-  F07.S0483 and F08.S0493.
-- FT03724 (RT=156.9, `[M+2Na-H]+` ion) with confidence level **B-**? In the
-  same feature group as FT02778 but associated MS2 spectrum don't match.
-- FT02450 (RT=157.8, `[M+H-H2O]+` ion) with confidence level **B-**.
+- FT02778 (RT=156.8, `[M+H]+` ion) with confidence level **A**.
+- FT03724 (RT=156.9, `[M+2Na-H]+` ion) with confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT02778_F07.S0483, FT02778_F08.S0493; high
+  confidence. `[M+2Na-H]+`: FT03724_F08.S0510; low confidence.
+  
 
 ### Phosphocreatine
 
@@ -1425,7 +1287,8 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra available.
+- Inconclusive.
+
 
 ### UDP-glucuronate
 
@@ -1517,7 +1380,9 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-The availble MS2 spectra do not matching any reference spectra for `r std`.
+- Inconclusive. Available MS2 spectra don't match and no features found for the
+  previously defined retention time.
+
 
 ### Valine
 
@@ -1567,20 +1432,6 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 We obtain similar matches (with similarity scores a bit lower) also for
 MassBank.
 
-Since F08.S0568 from FT01634 is associated to an ion different from `[M+H]+` we perform a neutral loss spectra comparison.
-
-```{r mix02-serum-pos-valine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2["FT01634_F08.S0568"], nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-pos-valine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2["FT01634_F08.S0568"], nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
@@ -1598,10 +1449,11 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-- FT00670 (RT= 166.9, `[M+H]+` ion) with confidence level **B** and reference
-  spectrum F07.S0550, F08.S0573?
-- FT01634 (RT = 167.1, `[M+2Na-H]+` ion) with confidence level **B-**? In the
-  same feature group as FT00670 but associated MS2 spectrum don't match.
+- FT00670 (RT= 166.9, `[M+H]+` ion) with confidence level **B**.
+- FT01634 (RT = 167.1, `[M+2Na-H]+` ion) with confidence level **B-**.
+- Reference MS2: `[M+H+]`: FT00670_F07.S0550, FT00670_F08.S0573; high
+  confidence. `[M+2Na-H]+`: FT01634_F08.S0568; low confidence.
+  
 
 # Serum, negative polarity
 

--- a/match-standards-serum-mix02.Rmd
+++ b/match-standards-serum-mix02.Rmd
@@ -25,7 +25,7 @@ FEATURE_MS2_TOLERANCE <- 0.05
 ```{r, general-settings, echo = FALSE, message = FALSE}
 ```
 
-**Current version: 0.9.0, 2022-03-09.**
+**Current version: 0.10.0, 2022-05-31.**
 
 # Introduction
 
@@ -67,6 +67,9 @@ ions (respectively `[M-H]-` ions for negative polarity) and add the m/z for
 these adducts as *precursor m/z*.
 
 ```{r, load-reference-databases, message = FALSE}
+```
+
+```{r, setup-ion-db, message = FALSE, echo = FALSE}
 ```
 
 # Initial evaluation of available MS2 data
@@ -304,8 +307,27 @@ perform_match(std_ms2_nl, mbank_nl,
   FT01572_F08.S0393, FT01572_F07.S0389; low confidence. `[M+2K-H]+`:
   FT03383_F07.S0390, FT03383_F07.S0428, FT03383_F08.S0387; low confidence.
 
+The associated ion and MS2 spectra are added to the database.
 
-### C4 Carnitine
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT01902", "FT01572", "FT03383"),
+                  confidence_level = c("C", "C", "C"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT01572_F07.S0389", "FT01572_F08.S0393", "FT01572_F07.S0389",
+                 "FT03383_F07.S0390", "FT03383_F07.S0428", "FT03383_F08.S0387")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
+### C4 Carnitine (Isobutyryl-L-carnitine)
+
 
 ```{r, echo = FALSE}
 std <- "C4 Carnitine"
@@ -365,6 +387,28 @@ sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
 For the HMDB comparison we don't find matches while for the MassBank one
 the neutral loss spectra cannot be computed. 
 
+Since the chemical formula used for this standard is essentially the one of
+Butyrylcarnitine (C4 Carnitine) and not the one of Isobotyryl-L-carnitine (the
+standard that was bought from Sigma Aldrich) we also match the MS2 spectra
+against the reference spectra from Butyrylcarnitine (HMDB0002013).
+
+```{r mix02-serum-pos-butyrylcarnitine-ms2-hmdb, echo = FALSE, fig.width = 5, fig.height = 5}
+hmdb_id <- "HMDB0002013"
+std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
+```
+
+We get matches with high similarity against the reference spectra from
+Butyrylcarnitine.
+
+```{r mix02-serum-pos-ascorbic-butyrylcarnitine-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
+                               ppm = csp@ppm, tolerance = csp@tolerance)
+```
+
+Similarity is quite high arguing that the standard measured here is
+Butyrylcarnitine, not Isobutyryl-L-carnitine.
+
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
@@ -401,15 +445,33 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- Inconclusive. Same as with water. MS2 spectra match butyrylcarnitine, not C4
-  carnitine. Maybe need to check back with Vinicius which standard was actually
-  bought and how the formula was defined (as it is the one of
-  butyrylcarnitine!).
-- FT02888 (RT = 37, `[M+H+]` ion) confidence level **D**? or **A** for
-  butyrylcarnitine.
+- FT02888 (RT = 37, `[M+H+]` ion) confidence level **A** (for
+  butyrylcarnitine).
 - FT03406 (RT = 36.46, `[M+Na]+` ion).
 - FT03708 (RT = 36.31, `[M+K]+` ion).
-  
+- Reference MS2 (assign to butyrylcarnitine).
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT02888", "FT03406", "FT03708"),
+                  confidence_level = c("A", "A-", "A-"))
+fts$note <- paste0("Ambiguous: standard is isobutyryl-L-carnitine (Sigma ",
+                   "Aldrich 51085), but matches butyrylcarnitine.")
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT02888_F07.S0128", "FT02888_F07.S0185", "FT02893_F07.S0241",
+                 "FT02891_F07.S0287", "FT02890_F07.S0400")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 
 ### Fructose
 
@@ -513,6 +575,17 @@ perform_match(std_ms2_nl, mbank_nl,
 - Reference MS2: `[M+Na]+`: FT02330_F08.S0476; low confidence. `[M+K]+`:
   FT02615_F07.S0456; low confidence.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT02330", "FT02615"),
+                  confidence_level = c("D", "D"))
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
 
 ### Glycine
 
@@ -588,6 +661,23 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - FT00174 (RT = 173.1, `[M+H]+` ion) with confidence **A**. 
 - Reference MS2: `[M+H]+`: FT00174_F07.S0587; high confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT00174"),
+                  confidence_level = c("A"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT00174_F07.S0587")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
   
 ### cGMP
 
@@ -629,7 +719,7 @@ The MS2 spectra from FT05702 match with high similarity score reference spectra
 from `r std`. We also have matches with very low similarity involving spectra
 from FT06569.
 
-```{r mix02-serum-pos-cgmp-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+```{r mix02-serum-pos-cgmp-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots", fig.width = 10, fig.height = 10}
 std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
@@ -683,6 +773,26 @@ perform_match(std_ms2_nl, mbank_nl,
   FT05702_F07.S0796, FT05702_F08.S0766, FT05702_F08.S0788, FT05702_F08.S0808;
   high confidence. `[M+Na]+`: FT06194_F08.S0782; low confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT05702", "FT06194", "FT06570"),
+                  confidence_level = c("A", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT05702_F07.S0757", "FT05702_F07.S0775", "FT05702_F07.S0796",
+                 "FT05702_F08.S0766", "FT05702_F08.S0788", "FT05702_F08.S0808",
+                 "FT06194_F08.S0782")]
+ms2$confidence <- c(rep("high", 6), "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 
 ### Histidine
 
@@ -772,6 +882,19 @@ perform_match(std_ms2_nl, mbank_nl,
 - FT02188 (RT = 185.3, `[M+K]+` ion) confidence level **A-**.
 - Reference MS2: `[M+H]+`: FT01452_F07.S0670, FT01452_F07.S0729,
   FT01452_F08.S0695; high confidence.
+  
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT01452_F07.S0670", "FT01452_F07.S0729", "FT01452_F08.S0695")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
   
   
 ### Hydroxyproline
@@ -865,6 +988,23 @@ perform_match(std_ms2_nl, mbank_nl,
   confidence. `[M+H-H2O]+`: FT00598_F07.S0623, FT00598_F08.S0648; low
   confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT00922", "FT00598", "FT01418"),
+                  confidence_level = c("A", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT00922_F07.S0648", "FT00922_F08.S0686", "FT00598_F07.S0623",
+                 "FT00598_F08.S0648")]
+ms2$confidence <- c("high", "high", "low", "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
 
 
 ### Hypoxanthine
@@ -963,6 +1103,26 @@ perform_match(std_ms2_nl, mbank_nl,
   confidence. `[M+H-H2O]+`: FT00681_F07.S0386, FT00681_F08.S0390; low
   confidence. `[M+Na]+`: FT01572_F08.S0393, FT01572_F07.S0389; low confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT01048", "FT01850", "FT00681", "FT01572"),
+                  confidence_level = c("A", "A-", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT01048_F07.S0377", "FT01048_F07.S0412", "FT01048_F08.S0381",
+                 "FT01048_F08.S0412", "FT01850_F07.S0378", "FT01850_F08.S0382",
+                 "FT01850_F08.S0414", "FT00681_F07.S0386", "FT00681_F08.S0390",
+                 "FT01572_F08.S0393", "FT01572_F07.S0389")]
+ms2$confidence <- c(rep("high", 4), rep("low", 7))
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 
 ### L-Kynurenine
@@ -1054,6 +1214,18 @@ perform_match(std_ms2_nl, mbank_nl,
 - Reference MS2: `[M+H]+`: FT02454_F07.S0465, FT02454_F08.S0478; high
   confidence. `[M+Na]+`: FT02859_F08.S0480; low confidence. `[M+2Na-H]+`:
   FT03386_F07.S0469, FT03386_F08.S0482; low confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT02454_F07.S0465", "FT02454_F08.S0478", "FT02859_F08.S0480",
+                 "FT03386_F07.S0469", "FT03386_F08.S0482")]
+ms2$confidence <- c(rep("high", 2), rep("low", 3))
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
 
 
 ### Lactic acid
@@ -1172,7 +1344,25 @@ perform_match(std_ms2_nl, mbank_nl,
 - Reference MS2: `[M+H]+`: FT01719_F07.S0273, FT01719_F08.S0266; high
   confidence. `[M+Na]+`: FT02107_F08.S0273; low confidence. `[M+2Na-H]+`:
   FT02478_F08.S0285; low confidence.
-  
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT02478"),
+                  confidence_level = c("A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT01719_F07.S0273", "FT01719_F08.S0266", "FT02107_F08.S0273",
+                 "FT02478_F08.S0285")]
+ms2$confidence <- c("high", "high", "low", "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### 3-Nitrotyrosine
 
@@ -1257,6 +1447,17 @@ perform_match(std_ms2_nl, mbank_nl,
 - Reference MS2: `[M+H]+`: FT02778_F07.S0483, FT02778_F08.S0493; high
   confidence. `[M+2Na-H]+`: FT03724_F08.S0510; low confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT02778_F07.S0483", "FT02778_F08.S0493", "FT03724_F08.S0510")]
+ms2$confidence <- c("high", "high", "low")
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Phosphocreatine
 
@@ -1454,6 +1655,17 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - Reference MS2: `[M+H+]`: FT00670_F07.S0550, FT00670_F08.S0573; high
   confidence. `[M+2Na-H]+`: FT01634_F08.S0568; low confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT00670_F07.S0550", "FT00670_F08.S0573", "FT01634_F08.S0568")]
+ms2$confidence <- c("high", "high", "low")
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 # Serum, negative polarity
 
@@ -1474,21 +1686,6 @@ hmdb_nl <- hmdb_neg_nl
 load(paste0(RDATA_PATH, paste0("processed_data_", POLARITY, ".RData")))
 data_FS <- filterFile(data, which(data$mode == "FS"),
                       keepFeatures = TRUE)
-```
-
-The base peak chromatogram and peak density image with the expected retention
-times for the standards is shown below.
-
-```{r mix02-serum-neg-bpc, echo = FALSE, caption = "Base peak chromatogram and chromatographic peak density image. Dashed vertical lines represent the expected retention times for the standards as defined in a previous manual analysis.", fig.width = 7, fig.height = 5}
-bpc <- chromatogram(data, aggregationFun = "max", msLevel = 1L,
-                    mz = c(60, 900), include = "none")
-par(mfrow = c(2, 1), mar = c(0, 20, 1.5, 0.5))
-plot(bpc, col = paste0(col_group[bpc$group], 80))
-legend("topright", col = col_group, lty = 1, legend = names(col_group))
-abline(v = std_dilution$RT, lty = 2)
-par(mar = c(4.5, 20, 0, 0.5))
-plotChromPeakImage(data, binSize = 3)
-abline(v = std_dilution$RT, lty = 2)
 ```
 
 
@@ -1528,6 +1725,90 @@ case.
 
 ## Standards with matching features
 
+### Ascorbic Acid
+
+```{r, echo = FALSE}
+std <- "Ascorbic Acid"
+```
+
+```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
+```
+
+Many features have been assigned to this standard based on
+m/z matching. Based on their retention times, these seem however to represent
+ions from different compounds.
+
+We next plot the EICs for the assigned features and visually inspect these.
+
+```{r, echo = FALSE}
+plot_eics(data, std, feature_table, "WN", std_ms2)
+```
+
+The cleaned MS2 spectra for the features matched to `r std` are shown below
+(peaks with an intensity below 5% of the maximum peak and spectra with less
+than 2 peaks where removed).
+
+```{r mix02-serum-neg-ascorbic-acid-ms2, echo = FALSE}
+plot_spectra(std_ms2)
+```
+
+We next match the extracted MS2 spectra against the reference spectra for 
+`r std` from HMDB and MassBank.
+
+```{r mix02-serum-neg-ascorbic-acid-ms2-hmdb, echo = FALSE, fig.width = 5, fig.height = 5}
+hmdb_id <- std_dilution$HMDB[std_dilution$name == std]
+std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
+```
+
+Some MS2 spectra match the reference, but with a low similarity score.
+
+```{r mix02-serum-neg-ascorbic-acid-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.6, ppm = csp@ppm,
+                               tolerance = csp@tolerance)
+```
+
+```{r mix02-serum-neg-ascorbic-acid-acid-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
+std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
+```
+
+No match was found for reference spectra from MassBank.
+
+In addition we match (**all**) the MS2 spectra for the matched features against
+all spectra from HMDB or MassBank identifying reference spectra with a
+similarity larger than 0.7. The results (if any spectra matched) are shown in
+the two following tables.
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+
+#### Summary
+
+- FT0705 (RT = 126.5, `[M-H]-` ion) with confidence **C**.
+- Reference MS2: `[M-H]-`: FT0705_F15.S0305, FT0705_F15.S0342, FT0705_F16.S0347;
+  low confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0705_F15.S0305", "FT0705_F15.S0342", "FT0705_F16.S0347")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 ### C4 Carnitine
 
 ```{r, echo = FALSE}
@@ -1555,8 +1836,21 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectrum available. The EIC of the only available feature maybe doesn't
-look very good.
+- Inconclusive.
+- FT1390 (RT = 34.54, `[M-H]-` ion) confidence level **D**. But only if we have
+  some other evidence (from pos, or water) too.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT1390"),
+                  confidence_level = c("D"))
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
 
 ### Fructose
 
@@ -1566,10 +1860,6 @@ std <- "Fructose"
 
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
-
-A single feature has been assigned to this standard based on
-m/z matching. We next plot its EIC and visually inspect it (has very
-low intensity).
 
 ```{r, echo = FALSE}
 plot_eics(data, std, feature_table, "WN", std_ms2)
@@ -1614,7 +1904,6 @@ similarity larger than 0.7. The results (if any spectra matched) are shown in
 the two following tables.
 
 ```{r, echo = FALSE, message = FALSE, results = "asis"}
-std_ms2_sel <- Spectra()
 perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
@@ -1624,13 +1913,30 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
 
-We find high score matches for spectra from FT0515 and spectra of compounds
-different from `r std` (e.g. Theophyline).
 
 #### Summary
 
-- FT0761 (RT = 151.5, `[M-H]-` ion) with confidence level **C**? MS2 spectrum
-  F16.S0457.
+- FT0761 (RT = 151.5, `[M-H]-` ion) with confidence level **C**.
+- Other features of other ions exist, but their EIC looks different.
+- Reference MS2: `[M-H]-`: FT0761_F16.S0457; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0761"),
+                  confidence_level = c("C"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0761_F16.S0457")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Glycine
 
@@ -1641,9 +1947,7 @@ std <- "Glycine"
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
 
-One single feature has been assigned to this standard based on m/z matching.
-Based on their retention times, these seem however to represent ions from two
-different compounds.
+One a single feature has been assigned to this standard based on m/z matching.
 
 We next plot the EIC for the assigned feature and visually inspect these.
 
@@ -1663,6 +1967,7 @@ plot_spectra(std_ms2)
 
 - FT0017 (RT=174, `[M-H]-` ion) with confidence level **D**. No MS2 spectra
   available.
+
 
 ### cGMP
 
@@ -1735,10 +2040,23 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-- FT3159 (RT = 219, `[M-H]-` ion) with confidence level **A** (or **B** looking
-  at MBank comparison?).
-  MS2 spectra: F15.S0685, F15.S0721, F16.S0711, F16.S0742, F16.S0767.
-- FT4018 (RT = 219, `[M-H]-` ion) same as above (in the same feature group).
+- FT3159 (RT = 219, `[M-H]-` ion) with confidence level **A**.
+- FT4018 (RT = 219, `[M+HCOO]-` ion) confidence level **A-**.
+- Reference MS2: `[M-H]-`: FT3159_F15.S0685, FT3159_F15.S0721, FT3159_F16.S0711,
+  FT3159_F16.S0742, FT3159_F16.S0767; high confidence.
+  
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT3159_F15.S0685", "FT3159_F15.S0721", "FT3159_F16.S0711",
+                 "FT3159_F16.S0742", "FT3159_F16.S0767")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Histidine
 
@@ -1779,7 +2097,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 All the extracted spectra match reference spectra from HMDB.
 
 ```{r mix02-serum-neg-histidine-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -1813,10 +2131,27 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 #### Summary
 
 - FT0466 (RT = 188.3, `[M-H]-` ion) with confidence level **A**.
-- FT0888 (RT = , `[M+Cl]-` ion) in the same feature group as FT0466: same
-  same confidence level.
-- FT0468 (RT = 224, `[M-H]-` ion) with confidence level **A**? EIC do not look
-  as good as the one for FT0466.
+- FT0888 (RT = , `[M+Cl]-` ion) with confidence level **A-**.
+- FT0468 (RT = 224, `[M-H]-` ion) with confidence level **A**? Maybe that's just
+  some leftover from the column?
+- Reference MS2: `[M-H]-`: FT0466_F15.S0603, FT0466_F15.S0684; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0466", "FT0888"),
+                  confidence_level = c("A", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0466_F15.S0603", "FT0466_F15.S0684")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
 
 
 ### Hydroxyproline
@@ -1842,12 +2177,52 @@ than 2 peaks where removed).
 plot_spectra(std_ms2)
 ```
 
+We next match the extracted MS2 spectra against the reference spectra for 
+`r std` from HMDB and MassBank. The MS2 spectrum does however not match the
+reference spectra.
+
+```{r mix02-serum-neg-hydroxyproline-ms2-hmdb, echo = FALSE, fig.width = 5, fig.height = 5}
+hmdb_id <- std_dilution$HMDB[std_dilution$name == std]
+std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
+```
+
+```{r mix02-serum-neg-hydroxyproline-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
+std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
+```
+
+```{r mix02-serum-neg-hydroxyproline-mirror-mbank, echo = TRUE, fig.cap = "Mirror plots"}
+tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.8, ppm = csp@ppm,
+                               tolerance = csp@tolerance)
+```
+
+In addition we match (**all**) the MS2 spectra for the matched features against
+all spectra from HMDB or MassBank identifying reference spectra with a
+similarity larger than 0.7. The results (if any spectra matched) are shown in
+the two following tables.
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+
 #### Summary
 
-No MS2 spectra available for the selected features. The best looking EICs are
-those for features FT0720, FT0244, FT0591. These feaures are in the same
-feature group (and their retention time is similar to the one found during
-previous analysis).
+- Inconclusive.
+- FT0244 (RT = 176.2, `[M-H]-` ion) looks good, but the MS2 spectrum (which is
+  also measured **before** the actual compound) matches creatine. Need thus
+  evidence from other matrices/polarity to decide.
+- FT0591 (RT = 176.9, `[M+Cl]-` ion).
+- FT0720 (RT = 174.9, `[M+HCOO]-` ion).
+
+
 
 ### Hypoxanthine
 
@@ -1899,22 +2274,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
 With the MassBank comparison we find the similar matches but with very low
-similarity score. In addition, since F16.S0229 from FT0787 is associated to an
-ion different from `[M-H]-` we perform a neutral loss spectra
-comparison. In this case, as we show below, we also find matches involving
-F16.S0229 but with very low similarity.
-
-```{r mix02-serum-neg-hypoxanthine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2["FT0787_F16.S0229"], nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-serum-neg-hypoxanthine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2["FT0787_F16.S0229"], nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
+similarity score.
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -1947,9 +2307,21 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT0318 (RT = 123.6, `[M-H]-` ion) with confidence level **B**. Spectra
-  F15.S0316 and F16.S0337.
-- FT0786 (RT = 124.6, `[M+HCOO]-` ion) inherits confidence level from FT0318.
+- FT0318 (RT = 123.6, `[M-H]-` ion) with confidence level **B**.
+- FT0786 (RT = 124.6, `[M+HCOO]-` ion) with confidence level **B-**.
+- Reference MS2: `[M-H]-`: FT0318_F15.S0316, FT0318_F16.S0337; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0318_F15.S0316", "FT0318_F16.S0337")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### L-Kynurenine
 
@@ -2039,9 +2411,11 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-No MS2 spectra match well against reference spectra from `r std`. The best
-looking EICs are those for FT1099 and FT1525 (same feature group and retention
-time similar to the one found in previous analysis).
+- Inconclusive. Depends on results from water and positive polarity.
+- FT1099 (RT = 156, `[M-H]-` ion) with confidence level **D**.
+- FT1642 (RT = 150.5, `[M+HCOO]-` ion) with confidence level **D-**.
+- FT1525 (RT = 156.1, `[M+Cl]-` ion) with confidence level **D-**.
+
 
 ### Lactic acid
 
@@ -2132,8 +2506,9 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-None of the two available MS2 spectra match reference standards from `r std`.
-These spectra are from FT0318 that was matched to Hypoxanthine as well.
+- Inconclusive. No signal at the expected RT.
+- FT0318 is in fact **Hypoxanthine**.
+
 
 ### 1-Methylxanthine
 
@@ -2203,8 +2578,21 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 #### Summary
 
 - FT0585 (RT = 71.6, `[M-H]-` ion) with confidence level **A**.
-  MS2 spectra: F15.S0210, F16.S0219, F16.S0251.
-- FT1146 (RT = 72.3, `[M+HCOO]-` ion) in the same feature group as FT0585.
+- FT1146 (RT = 72.3, `[M+HCOO]-` ion) with confidence level **A-**.
+- Reference MS2: `[M-H]-`: FT0585_F15.S0210, FT0585_F16.S0219, FT0585_F16.S0251;
+  high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0585_F15.S0210", "FT0585_F16.S0219", "FT0585_F16.S0251")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### 3-Nitrotyrosine
 
@@ -2270,24 +2658,30 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
 
-For completeness, we also perform a neutral loss spectra comparison with HMDB
-and MassBank.
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, hmdb_nl, sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, mbank_nl,
-              sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
 
 #### Summary
 
-- FT1305 (RT = 152.1, `[M-H]-` ion) with confidence **A**. MS2 spectra : FT1305
-  and F16.S0459.
+- FT1305 (RT = 156.1, `[M-H]-` ion) with confidence **A**.
+- FT1761 (RT = 157.4, `[M+Cl]-` ion) with confidence **A-**.
+- Reference MS2: `[M-H]-`: FT1305_F15.S0425, FT1305_F16.S0459; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT1305", "FT1761"),
+                  confidence_level = c("A", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT1305_F15.S0425", "FT1305_F16.S0459")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Phosphocreatine
 
@@ -2298,9 +2692,7 @@ std <- "Phosphocreatine"
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
 
-Many features have been assigned to this standard based on
-m/z matching. Based on their retention times, these seem however to represent
-ions from different compounds.
+Only a single feature was found.
 
 We next plot the EIC for the assigned feature and visually inspect these.
 
@@ -2318,7 +2710,9 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra available.
+- Inconclusive? Low signal.
+- FT1136 (RT = 206, `[M-H]-` ion) with confidence **D**.
+
 
 ### UDP-glucuronate
 
@@ -2329,9 +2723,7 @@ std <- "UDP-glucuronate"
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
 
-Many features have been assigned to this standard based on
-m/z matching. Based on their retention times, these seem however to represent
-ions from different compounds.
+A single feature was found, with low intensity and not at the expected RT.
 
 We next plot the EIC for the assigned feature and visually inspect these.
 
@@ -2349,7 +2741,9 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra available. 
+- Inconclusive. Signal of the only feature is low, and also no large difference
+  between low and high concentration.
+
 
 ### Valine
 
@@ -2360,10 +2754,7 @@ std <- "Valine"
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
 
-Many features have been assigned to this standard based on
-m/z matching. Based on their retention times, these seem however to represent
-ions from different compounds.
-
+Two features with about the same retention time were found.
 We next plot the EIC for the assigned feature and visually inspect these.
 
 ```{r, echo = FALSE}
@@ -2380,11 +2771,18 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra available. EIC of FT0152 shows high intensity signal differently 
-from FT0542. Both features have retention time similar to the one found for
-`r std` with previous analysis.
+- FT0152 (RT = 166.7, `[M-H]-` ion) with confidence **D**.
+- FT0542 (RT = 166.8, `[M+HCOO]-` ion) with confidence **D-**.
+
 
 ## Standards without any matching feature
+
+# Summary on the ion database
+
+Summarizing the content that was added to the `IonDb`.
+
+```{r, iondb-summary, echo = FALSE, results = "asis"}
+```
 
 # Session information
 

--- a/match-standards-water-mix01.Rmd
+++ b/match-standards-water-mix01.Rmd
@@ -15,6 +15,9 @@ knitr::read_chunk("R/match-standards-chunks.R")
 MIX <- 1
 MATRIX <- "Water"
 POLARITY <- "POS"
+## settings to find MS2 spectra for features. Be rather inclusive here.
+FEATURE_MS2_PPM <- 20
+FEATURE_MS2_TOLERANCE <- 0.05
 ```
 
 ```{r, libraries, echo = FALSE, message = FALSE}
@@ -102,7 +105,7 @@ Standards for which no MS2 spectrum in HMDB is present are listed in
 the table below.
 
 ```{r, echo = FALSE, results = "asis"}
-tmp <- std_dilution01[!(std_dilution01$HMDB %in% hmdb_std$compound_id), ]
+tmp <- std_dilution[!(std_dilution$HMDB %in% hmdb_std$compound_id), ]
 pandoc.table(tmp[, c("name", "HMDB", "formula")], style = "rmarkdown",
              caption = "Standards for which no reference spectrum is available")
 ```
@@ -190,7 +193,7 @@ removed.
 ```
 
 For most of the standards (`r length(unique(mD$target_name))` out of 
-`r nrow(std_dilution01)`) in mix `r MIX` at least one feature was found
+`r nrow(std_dilution)`) in mix `r MIX` at least one feature was found
 matching the standards adducts' m/z. 
 
 ```{r, table-standard-no-feature, results = "asis", echo = FALSE}
@@ -896,6 +899,7 @@ standard but again we obtain no match.
 std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
+
 Since the extracted spectrum is associated to
 an ion different from `[M+H]+` (`[M+2Na-H]+`) we also perform a comparison
 between the neutral loss spectra from HMDB and MassBank.
@@ -1741,7 +1745,7 @@ removed.
 ```
 
 For most of the standards (`r length(unique(mD$target_name))` out of 
-`r nrow(std_dilution01)`) in mix `r MIX` at least one feature was found
+`r nrow(std_dilution)`) in mix `r MIX` at least one feature was found
 matching the standards adducts' m/z. 
 
 ```{r, table-standard-no-feature, results = "asis", echo = FALSE}

--- a/match-standards-water-mix02.Rmd
+++ b/match-standards-water-mix02.Rmd
@@ -15,6 +15,9 @@ knitr::read_chunk("R/match-standards-chunks.R")
 MIX <- 2
 MATRIX <- "Water"
 POLARITY <- "POS"
+## settings to find MS2 spectra for features. Be rather inclusive here.
+FEATURE_MS2_PPM <- 20
+FEATURE_MS2_TOLERANCE <- 0.05
 ```
 
 ```{r, libraries, echo = FALSE, message = FALSE}
@@ -142,17 +145,8 @@ We perform the pre-processing of our data set which consists of the
 chromatographic peak detection followed by a peak refinement step to reduce peak
 detection artifacts, the correspondence analysis to group peaks across samples
 and finally the gap-filling to fill in missing peak data from samples in which
-no chromatographic peak was detected.
-
-Some notes on the settings for the pre-processing:
-
-- The `bw` parameter for the correspondence is larger than usual because adding
-  the standards in higher concentrations caused considerable retention time
-  shifts for some. A higher `bw` will allow to group also mis-aligned
-  chromatographic peaks - but will not allow to discriminate between closely
-  eluting ions.
-- The `binSize` was also slightly increased to avoid splitting of features with
-  similar m/z values.
+no chromatographic peak was detected. For details on settings please refer to
+the analysis of *mix 01* samples.
 
 ```{r, preprocessing, eval = !file.exists(paste0(RDATA_PATH, "processed_data_", POLARITY, ".RData")), message = FALSE}
 ```
@@ -248,34 +242,18 @@ std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 ```
 
+One spectrum matches reference spectra quite well. Interestingly, the precursor
+m/z don't match suggesting potentially a not well calibrated instrument?
+
+```{r mix02-water-pos-ascorbic-acid-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+tmp_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.5,
+                           ppm = csp@ppm, tolerance = csp@tolerance)
+```
+
 ```{r mix02-water-pos-ascorbic-acid-acid-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
 std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
-
-In both cases we don't find any match. In addition, since all the extracted
-spectra are associated to ions different from `[M+H]+` we perform a neutral
-loss spectra comparison.
-
-```{r mix02-water-pos-ascorbic-acid-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
-```
-
-```{r mix02-water-pos-ascorbic-acid-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2_nl, std_hmdb_nl, 0.05,
-                           ppm = csp@ppm, tolerance = csp@tolerance)
-```
-
-```{r mix02-water-pos-ascorbic-acid-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
-std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
-std_ms2_nl <- neutralLoss(std_ms2, nl_param)
-sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
-```
-
-For the HMDB comparison we don't find good matches while for the MassBank one
-the neutral loss spectra cannot be computed. 
 
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
@@ -308,13 +286,16 @@ perform_match(std_ms2_nl, mbank_nl,
 ```
 
 We find some matches for extracted spectra from FT2095 and FT2096 with other
-compounds than `r std` and with similarity around 0.7.
+compounds than `r std` and with similarity around 0.7, the difference between
+their precursor m/z values is however large.
 
 #### Summary
 
-No good MS2 spectra match was found. The best looking EICs are those for FT1811
-(its retention time is close to the retantion time associated to Ascorbic acid
-by previous analysis) and FT2465 but no associated MS2 spectra are available.
+- Annotation of FT1811 (RT=128, `[M+H]+` ion) to `r std` with confidence level
+  **C**.
+- Reference MS2: FT1811 `[M+H+]`: FT1811_F07.S0399 (high confidence),
+  FT1811_F08.S0391 (low confidence).
+  
 
 ### C4 Carnitine
 
@@ -410,10 +391,18 @@ perform_match(std_ms2_nl, mbank_nl,
               name = "target_name", param = csp_nl)
 ```
 
+
 #### Summary
 
-Many MS2 spectra can be extracted but none of them matches reference spectra
-from `r std`. They seem to match reference spectra from other compounds.
+- MS2 spectra for features FT2682 (RT=123), FT2685 (RT=167), FT2683 (RT=143),
+  FT2684 (RT=37) and FT2686 (RT=44) match Butyrylcarnitine (C11H21NO4) but not
+  the actual carnitine (C11H22NO4), i.e. with one H more. Note also that the
+  formula used for this compound matches the one of butyrylcarnitine!
+- What is however very strange is that EICs are present along the whole
+  retention time range.
+- Check with Vinicius: what was the actual compound used? Why was the formula
+  adapted?
+
 
 ### Fructose
 
@@ -468,8 +457,10 @@ sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
 
 ```{r mix02-water-pos-fructose-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
 tmp_sel <- plot_select_ms2(std_ms2_nl, std_hmdb_nl, 0.05,
-                           ppm = csp@ppm, tolerance = csp@tolerance)
+                           ppm = csp_nl@ppm, tolerance = csp_nl@tolerance)
 ```
+
+We have a match for one peak.
 
 ```{r mix02-water-pos-fructose-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
 std_mbank_nl <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey), nl = TRUE)
@@ -512,7 +503,13 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-The available MS2 spectra do not match any reference spectra from `r std`.
+- Inconclusive.
+- From the EICs it looks like the signal is measured around 150-160 seconds. But
+  these match to `[M+Na]+` ions and the related MS2 spectra don't match
+  `r std`.
+- We could assign the features with confidence **D** and the MS2 spectra with
+  low confidence.
+  
 
 ### Glycine
 
@@ -585,6 +582,7 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 - FT0102 (RT = 173.7, `[M+H]+` ion) with confidence **C**: the MS2 spectrum
   F08.S0584 matches only `r std` with a low similarity.
+- Reference MS2: `[M+H]+`: FT0102_F08.S0584; low confidence.
 
 ### cGMP
 
@@ -675,27 +673,14 @@ Reference spectra seem to match only with `r std` (in the MassBank case the
 listed compounds have the same inchikey as `r std` so could it be they are
 the same?).
 
-For completeness, we also perform a neutral loss spectra comparison with HMDB
-and MassBank.
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, hmdb_nl, sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, mbank_nl,
-              sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
 
 #### Summary
 
 - FT4591 (RT = 213, ion `[M+H]+`): confidence **A**.
-- FT4903 (RT = 212.6, ion `[M+Na]+`): confidence **A-** inherited from FT4591
-  or **C** since the associated neutral loss spectrum matches with similarity
-  lower than 0.7 (around 0.5)?
-- Reference spectra F07.S0777 for `[M+H]+` (and F08.S0748 for `[M+Na]+`)?
+- FT4903 (RT = 212.6, ion `[M+Na]+`): confidence **A-**.
+- Reference MS2: `[M+H]+`: FT4591_F07.S0777; high confidence, FT4591_F07.S0735,
+  FT4591_F08.S0747: low confidence. `[M+Na]+`: FT4903_F08.S0748?
+  
 
 ### Histidine
 
@@ -754,14 +739,14 @@ loss spectra comparison.
 
 ```{r mix02-water-pos-histidine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
 std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
-sp<- c("FT2093_F07.S0663", "FT1042_F07.S0381", "FT1042_F08.S0380")
+sp <- c("FT2093_F07.S0663", "FT1042_F07.S0381", "FT1042_F08.S0380")
 std_ms2_nl <- neutralLoss(std_ms2[sp], nl_param)
 sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_hmdb_nl, csp_nl)
 ```
 
 ```{r mix02-water-pos-histidine-mirror-hmdb_nl, echo = TRUE, fig.cap = "Mirror plots"}
 tmp_sel <- plot_select_ms2(std_ms2_nl, std_hmdb_nl, 0.15,
-                           ppm = csp@ppm, tolerance = csp@tolerance)
+                           ppm = csp_nl@ppm, tolerance = csp_nl@tolerance)
 ```
 
 ```{r mix02-water-pos-histidine-ms2-mbank_nl, echo = FALSE, fig.width = 5, fig.height = 5}
@@ -803,18 +788,13 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-We have matches for three features with same ion but different retention times?
-- FT1369 (RT = 213.2, `[M+H]+` ion) confidence level **B** (also reference
-  spectra of compounds different from `r std` match with similarity higher
-  than 0.7). Reference spectra: F07.S0730 and F08.S0740?
-or
-- FT1368 (RT = 189.9, `[M+H]+` ion) confidence level **B**. Reference spectra: 
-  F08.S0740 and F08.S0658?
-or
-- FT1376 (RT = 33.1, `[M+H]+` ion) confidence level **C** (spectra similarity
-  around 0.64). Maybe to exclude?
-In addition features inheriting confidence level from one of the features above
-for being in the same feature group.
+- FT1368 (RT=189.9, `[M+H]+` ion) confidence level **A**.
+- FT1832 (RT=190.4, `[M+Na]+` ion) confidence level **A-**.
+- FT2093 (RT=184.3, `[M+K]+` ion) confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT1368_F07.S0668, FT1368_F08.S0658, FT1368_F08.S0740,
+  FT1369_F07.S0730; high confidence. `[M+K]+`: FT2093_F07.S0663; low confidence.
+- Feature FT1376, which MS2 also match reference spectra for `r std` matches
+  also phenylpyridine and is thus most likely **not** `r std`.
 
   
 ### Hydroxyproline
@@ -857,7 +837,7 @@ The best matchings spectra are F07.S0659 and F08.S0644 from FT0790.
 Also F08.S0257 and F07.S0255 from FT0789 match (with similarity around 0.65).
  
 ```{r mix02-water-pos-hydroxyproline-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
                                ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
@@ -866,9 +846,8 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-In both cases we don't find any match. In addition, since F08.S0585 from FT0516
-is associated to an ion different from `[M+H]+` we perform a neutral
-loss spectra comparison.
+In addition, since F08.S0585 from FT0516 is associated to an ion different from
+`[M+H]+` we perform a neutral loss spectra comparison.
 
 ```{r mix02-water-pos-hydroxyproline-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
 std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
@@ -920,10 +899,12 @@ perform_match(std_ms2_nl, mbank_nl,
 #### Summary
 
 - FT0790 (RT = 175.3, `[M+H]+`): confidence level **B**.
-- FT0516 (RT = 175.3, `[M+H]+`): one one hand it should inherit confidence level
-  from FT0790 and on the other the associated MS2 spectrum don't match the
-  reference ones.
-- FT0789 (RT = 74.4, `[M+H]+`): confidence level **C** ?
+- FT0516 (RT = 175.3, `[M+H-H2O]+`): confidence level **B-**. The MS2 spectrum
+  from this compound will be discarded.
+- Reference MS2: `[M+H]+`: FT0790_F08.S0599, FT0790_F07.S0659, FT0790_F08.S0644;
+  high confidence. FT0790_F07.S0613; low confidence.
+- It is unclear what to do with FT0789 (RT = 74.4, `[M+H]+`): which MS2 spectra
+  also matches the compound of interest, but with a lower score?
 
 
 ### Hypoxanthine
@@ -993,7 +974,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
 ```
 
 With neutral loss comparison we find new matches for spectrum
-F07.S03789 from FT1777 in both the HMDB and MassBank case (with similarity
+F07.S0378 from FT1777 in both the HMDB and MassBank case (with similarity
 around 0.63).
 
 In addition we match (**all**) the MS2 spectra for the matched features against
@@ -1028,13 +1009,13 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT0955 (RT = 126.1, ion `[M+H]+`): confidence level **B**. Reference spectra:
-  F07.S0376 (and also F08.S0374).
-- FT0611 (RT = 126.1, ion `[M+H-H2O]+`): confidence level **B-** (because in the
-  same feature group as FT0955) but the associated MS2 don't match well.
-- FT1777 (RT = 126.1, ion `[M+K]+`): confidence level **C**.
-  Reference spectra F07.S03789?
-  
+- FT0955 (RT = 126.1, ion `[M+H]+`): confidence level **A**.
+- FT0611 (RT = 126.3, ion `[M+H-H2O]+`): confidence level **C**.
+- FT1777 (RT = 123.9, ion `[M+K]+`): confidence level **C**.
+- Reference MS2: `[M+H]+`: FT0955_F07.S0376, FT0955_F08.S0374; high
+  confidence. `[M+H-H2O]+`: FT0611_F07.S0374, FT0611_F08.S0372; low confidence.
+  `[M+K]+`: FT1777_F07.S0378, FT1777_F08.S0381; low confidence.
+
 ### L-Kynurenine
 
 ```{r, echo = FALSE}
@@ -1048,7 +1029,8 @@ Many features have been assigned to this standard based on
 m/z matching. Based on their retention times, these seem however to represent
 ions from different compounds.
 
-We next plot the EIC for the assigned feature and visually inspect these.
+We next plot the EIC for the assigned feature and visually inspect these. Most
+of the features above represent noisy and inconsistent data.
 
 ```{r, echo = FALSE}
 plot_eics(data, std, feature_table, "WP", std_ms2)
@@ -1076,7 +1058,7 @@ We find matches with high similarity for extracted MS2 spectra from FT2299
 slightly lower similarity from FT2069 (F07.S0476 and F08.S0478).
 
 ```{r mix02-water-pos-l-kynurenine-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.9, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -1139,35 +1121,18 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-This one is complicated. Also in this situation we have two different features
-that could be assigned to the `[M+H]+` ion of the standard.
+- FT2299 (RT = 153.9, `[M+H]+` ion) confidence level **A**.
+- FT2069 (RT = 153.9, `[M+H-NH3]+` ion) confidence level **C**.
+- FT2654 (RT = 154.4, `[M+Na]+` ion) confidence level **C**.
+- FT3226 (RT = 157.7, `[M+2Na-H]+` ion) confidence level **C**.
+- Reference MS2: `[M+H]+`: FT2299_F07.S0477, FT2299_F08.S0479; high
+  confidence. `[M+H-NH3]+`: FT2069_F07.S0476, FT2069_F08.S0478; high
+  confidence. `[M+Na]+`: FT2654_F07.S0479, FT2654_F08.S0481; low
+  confidence. `[M+2Na-H]+`: FT3226_F07.S0480, FT3226_F08.S0482; low confidence.
+- Feature FT2301 (RT = 164, `[M+H]+` ion) will be ignored as the retention time
+  is about 10 seconds delayed and its signal is much lower than for the
+  first. So maybe that is just some *left over* from the column (?).
 
-- FT2299 (RT = 153.9, `[M+H]+` ion) with confidence level **B** or **A** (are
-  by any chance L-Kynurenine and D-Kynurenine the same?). Reference spectra:
-  F07.S0477 (and F08.S0479?)
-- FT2301 (RT = 164, `[M+H]+` ion) similar to above. Reference spectra:
-  F07.S0570 and F08.S0577.
-  
-In addition we have:
-
-- FT2069 (RT = 153.9, `[M+H-NH3]+` ion) with confidence level **C** (maximum
-  similarity of associated F08.S0478 spectrum around 0.64) or higher similarity
-  inherited from FT2299.
-
-and the features matched with neutral loss spectra comparison:
-
-- Looking at the EICs FT3226 and FT3227 (both `[M+2Na-H]+`) seem to be somewhat
-  related (in the one for FT3227 we have the same profile as the peaks in
-  FT3226 but not identified as peak). The same happens for FT2657 and FT2654
-  (both `[M+Na]+`). FT2654 and FT3226 are also in the same feature group as 
-  FT2299.
-
-Further features considering feature groups:
-
-- FT0362, FT2053, FT3157
-- FT2071 and FT2656 were grouped with FT2301
-
-In these last few cases the EICs are low intensity and maybe not that good.
 
 ### Lactic acid
 
@@ -1198,7 +1163,8 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra, EICs maybe not very convincing.
+- Inconclusive. Low signal.
+
 
 ### 1-Methylxanthine
 
@@ -1264,14 +1230,6 @@ std_ms2_nl <- neutralLoss(std_ms2, nl_param)
 sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
 ```
 
-We obtain similar results with neutral loss comparison except other low
-similarity matches e.g. for F07.S0294 and (features FT2024 and FT2025).
-
-```{r, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2,
-                           std_hmdb, 0.7, ppm = csp@ppm, tolerance = csp@tolerance)
-```
-
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
@@ -1303,23 +1261,18 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT1642 (RT = 81.1, `[M+H]+` ion) with confidence level **A**. Associated
-  spectra: F08.S0270 and F07.S0271
+- FT1642 (RT = 81.1, `[M+H]+` ion) with confidence level **A**.
 Inheriting confidence level from FT1642 for being in the same feature group: 
-- FT2024 (RT = 80.2, `[M+Na]+` ion) with confidence level **A-**. However the 
-  4 MS2 spectra associated to this feature don't match well reference spectra
-  from 
+- FT2024 (RT = 80.2, `[M+Na]+` ion) with confidence level **A-**.
 - FT2249 (RT = 79.9, `[M+K]+` ion) with confidence level **A-**.
 - FT3108 (RT = 79.2, `[M+2K-H]+` ion) with confidence level **A-**.
-
-- FT1646 (RT = 63.5, `[M+H]+` ion) with confidence level **A**. Reference
-  spectra : F07.S0185, F08.S0190, F08.S0227. 
+- Reference MS2: `[M+H]+`: FT1642_F07.S0223, FT1642_F07.S0271, FT1642_F08.S0270,
+  FT1646_F07.S0185, FT1646_F08.S0190, FT1646_F08.S0227; high
+  confidence. `[M+Na]+`: FT2024_F07.S0294, FT2024_F08.S0214, FT2024_F08.S0261,
+  FT2024_F08.S0286; low confidence.
+- FT1646: this EIC is partially overlapping with FT1642 and will thus be ignores
+  (but its MS2 spectra will be added).
   
-For this last feature the retention time is not close to the RT found in
-previous analysis but spectra matches have a very high similarity score.
-Looking at the EICs of both FT1646 and FT1642 it would seem that they
-have been separated but maybe they shouldn't.
-
 
 ### 3-Nitrotyrosine
 
@@ -1419,8 +1372,11 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-- FT2571 (RT=164, `[M+H]+` ion) with confidence level **B**.
-- FT3454 (RT=161.5, `[M+2Na-H]+` ion) with confidence level **B-**.
+- FT2571 (RT=164, `[M+H]+` ion) with confidence level **A**.
+- FT3454 (RT=161.5, `[M+2Na-H]+` ion) with confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT2571_F07.S0574; high confidence. `[M+2Na-H]+`:
+  FT3454_F08.S0505; low confidence.
+  
 
 ### Phosphocreatine
 
@@ -1522,15 +1478,8 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-In this case we don't have high similarity spectra matches.
-
-- FT2352 (RT= 211.3, `[M+H]+` ion) with confidence level **C**. Consider
-  F07.S0726 as reference spectra?
-- FT2094 (RT= 209.7, `[M+H-H2O]+` ion) with confidence level **C-**? EIC
-  doesn't look very good and low intensity.
-- FT2093 (RT= 184.3, `[M+H-H2O]+` ion) with confidence level **C**?
-- FT2353 (RT= 196.3, `[M+H]+` ion) with confidence level **C**?
-- FT3261 (RT= 191.4, `[M+H]+` ion) with confidence level **C**?
+- FT2352/FT2353 (RT = 196.3, `[M+H]+` ion) with confidence level **C**.
+- Reference MS2: `[M+H]+`: FT2352_F07.S0726; low confidence.
   
 
 ### UDP-glucuronate
@@ -1628,7 +1577,8 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-Only one MS2 spectrum available but not matching reference spectra for `r std`.
+- Inconclusive.
+
 
 ### Valine
 
@@ -1710,9 +1660,11 @@ Also D-Valine is different from L-Valine?
 
 #### Summary
 
-- FT0594 (RT= 158.6, `[M+H]+` ion) with confidence level **A** and reference
-  spectrum F07.S0533?
+- FT0594 (RT= 158.6, `[M+H]+` ion) with confidence level **A**.
 - FT1553 (RT = 157.5, `[M+2Na-H]+` ion) with confidence level **A-**?
+- Reference MS2: `[M+H]+`: FT0594_F07.S0533; high confidence. FT0594_F08.S0494;
+  low confidence.
+
 
 # Water, negative polarity
 
@@ -1733,21 +1685,6 @@ hmdb_nl <- hmdb_neg_nl
 load(paste0(RDATA_PATH, paste0("processed_data_", POLARITY, ".RData")))
 data_FS <- filterFile(data, which(data$mode == "FS"),
                       keepFeatures = TRUE)
-```
-
-The base peak chromatogram and peak density image with the expected retention
-times for the standards is shown below.
-
-```{r mix02-water-neg-bpc, echo = FALSE, caption = "Base peak chromatogram and chromatographic peak density image. Dashed vertical lines represent the expected retention times for the standards as defined in a previous manual analysis.", fig.width = 7, fig.height = 5}
-bpc <- chromatogram(data, aggregationFun = "max", msLevel = 1L,
-                    mz = c(60, 900), include = "none")
-par(mfrow = c(2, 1), mar = c(0, 20, 1.5, 0.5))
-plot(bpc, col = paste0(col_group[bpc$group], 80))
-legend("topright", col = col_group, lty = 1, legend = names(col_group))
-abline(v = std_dilution$RT, lty = 2)
-par(mar = c(4.5, 20, 0, 0.5))
-plotChromPeakImage(data, binSize = 3)
-abline(v = std_dilution$RT, lty = 2)
 ```
 
 
@@ -1787,6 +1724,83 @@ case.
 
 ## Standards with matching features
 
+### Ascorbic Acid
+
+```{r, echo = FALSE}
+std <- "Ascorbic Acid"
+```
+
+```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
+```
+
+Many features have been assigned to this standard based on
+m/z matching. Based on their retention times, these seem however to represent
+ions from different compounds.
+
+We next plot the EICs for the assigned features and visually inspect these.
+
+```{r, echo = FALSE}
+plot_eics(data, std, feature_table, "WN", std_ms2)
+```
+
+The cleaned MS2 spectra for the features matched to `r std` are shown below
+(peaks with an intensity below 5% of the maximum peak and spectra with less
+than 2 peaks where removed).
+
+```{r mix02-water-neg-ascorbic-acid-ms2, echo = FALSE}
+plot_spectra(std_ms2)
+```
+
+We next match the extracted MS2 spectra against the reference spectra for 
+`r std` from HMDB and MassBank.
+
+```{r mix02-water-neg-ascorbic-acid-ms2-hmdb, echo = FALSE, fig.width = 5, fig.height = 5}
+hmdb_id <- std_dilution$HMDB[std_dilution$name == std]
+std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
+```
+
+MS2 spectra for features FT0475 and FT0476 match the reference spectra well.
+
+```{r mix02-water-neg-ascorbic-acid-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
+                               ppm = csp@ppm, tolerance = csp@tolerance)
+```
+
+```{r mix02-water-neg-ascorbic-acid-acid-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
+std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
+```
+
+No spectrum matches reference spectra from MassBank.
+
+In addition we match (**all**) the MS2 spectra for the matched features against
+all spectra from HMDB or MassBank identifying reference spectra with a
+similarity larger than 0.7. The results (if any spectra matched) are shown in
+the two following tables.
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+```{r, echo = FALSE, message = FALSE, results = "asis"}
+perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
+              name = "target_name", param = csp)
+```
+
+
+#### Summary
+
+- Annotation of FT0475 (RT = 125.9, `[M-H]-` ion) to `r std` with confidence
+  level **A**.
+- Reference MS2: `[M-H]-`: FT0475_F15.S0311, FT0475_F16.S0290, FT0475_F16.S0326;
+  high confidence.
+- Feature FT0476 (RT = 36.75, `[M-H]-` ion) matches also with its MS2 spectra to
+  the current compound, but signal is much lower than for the feature with
+  higher retention time.
+  
+
 ### C4 Carnitine
 
 ```{r, echo = FALSE}
@@ -1814,8 +1828,8 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectrum available. The EIC of the only available feature maybe doesn't
-look very good.
+- Inconclusive.
+
 
 ### Fructose
 
@@ -1885,7 +1899,10 @@ different from `r std` (e.g. Theophyline).
 
 #### Summary
 
-- FT0153 (RT = 152.1 with, `[M-H]-` ion) with confidence level **C-**?
+- FT0153 (RT = 152.1 with, `[M-H]-` ion) with confidence level **D**.
+- Not sure what to do with the reference spectrum. Does not look to be matching
+  properly to anything and thus we're discarding it.
+  
 
 ### Glycine
 
@@ -1926,8 +1943,8 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 We find a match (involving a single peak) and we report the mirror plot below.
 
 ```{r mix02-water-neg-glycine-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
-                           ppm = csp@ppm, tolerance = csp@tolerance)
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
+                               ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
 We find similar results for MassBank as shown below.
@@ -1936,8 +1953,6 @@ We find similar results for MassBank as shown below.
 std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
-
-In both cases we don't find any match. 
 
 ```{r mix02-water-neg-glycine-mirror-mbank, echo = TRUE, fig.cap = "Mirror plots"}
 tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.7,
@@ -1950,7 +1965,6 @@ similarity larger than 0.7. The results (if any spectra matched) are shown in
 the two following tables.
 
 ```{r, echo = FALSE, message = FALSE, results = "asis"}
-std_ms2_sel <- Spectra()
 perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
@@ -1962,8 +1976,9 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-- FT0013 (RT=170.6, `[M-H]-` ion) with confidence level **B**. MS2 spectra
-  F16.S0546?
+- FT0013 (RT = 170.6, `[M-H]-` ion) with confidence level **A**.
+- Reference MS2: `[M-H-]`: FT0013_F16.S0546; high confidence.
+
 
 ### cGMP
 
@@ -2001,7 +2016,7 @@ std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 ```
 
-All the spectra from FT2364 (F15.S0611, F15.S0654, F16.S0644) seem to match.
+All the spectra from FT2364 (F15.S0611, F15.S0654, F16.S0644) match well.
 
 ```{r mix02-water-neg-cgmp-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
 std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
@@ -2035,9 +2050,11 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-- FT2364 (RT = 213, `[M-H]-` ion) with confidence level **A** (or **B**?).
-  MS2 spectra: F15.S0611, F15.S0654, F16.S0644
-- FT2846 (RT = 213, `[M-H]-` ion) same as above (in the same feature group).
+- FT2364 (RT = 213, `[M-H]-` ion) confidence level **A**.
+- FT2846 (RT = 213.3 `[M+HCOO]-` ion) confidence level **A-**.
+- Reference MS2: `[M-H]-`: FT2364_F15.S0611, FT2364_F15.S0654, FT2364_F16.S0644;
+  high confidence.
+  
 
 ### Histidine
 
@@ -2080,7 +2097,7 @@ HMDB. The best matching ones are F15.S0548 from FT0309 and F15.S0597
 from FT0311.
 
 ```{r mix02-water-neg-histidine-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8, ppm = csp@ppm,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -2092,7 +2109,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
 ```{r mix02-water-neg-histidine-mirror-mbank, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.8, ppm = csp@ppm,
+tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.7, ppm = csp@ppm,
                                tolerance = csp@tolerance)
 ```
 
@@ -2113,10 +2130,11 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-- FT0309 (RT = 189.3, `[M-H]-` ion) with confidence level **A**? MS2 spectrum
-  F15.S0548, F16.S0574.
-- FT0311 (RT =  206.7) , `[M-H]-` ion) with confidence level **A**? MS2 spectra
-  F15.S0597. F16.S0631.
+- FT0309 (RT = 189.3, `[M-H]-` ion) with confidence level **A**.
+- While also for the other features MS2 spectra match the reference they will
+  not be considered (much lower signal).
+- Reference MS2: `[M-H]-`: FT0309_F15.S0548, FT0309_F16.S0574; high confidence.
+
 
 ### Hydroxyproline
 
@@ -2157,7 +2175,7 @@ We find matches for spectra F15.S0516 with very high scores and with lower
 scores also for F16.S0551.
  
 ```{r mix02-water-neg-hydroxyproline-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
-std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.8,
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
                                ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
@@ -2169,7 +2187,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
 ```{r mix02-water-neg-hydroxyproline-mirror-mbank, echo = TRUE, fig.cap = "Mirror plots"}
-tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.8,
+tmp_sel <- plot_select_ms2(std_ms2, std_mbank, 0.7,
                                ppm = csp@ppm, tolerance = csp@tolerance)
 ```
 
@@ -2194,10 +2212,11 @@ different (?) from `r std`.
 
 #### Summary
 
-- FT0153 (RT = 175.2, `[M-H]-` ion) with confidence **B**. Spectra F15.S0516
-  (and F16.S0551).
-- FT0404 (RT = 174.7, `[M+Cl]-` ion) with confidence **B-**.
-- FT0153 (RT = 174.6, `[M+HCOO]-` ion) with confidence **B-**.
+- FT0153 (RT = 175.2, `[M-H]-` ion) with confidence **A**.
+- FT0404 (RT = 174.7, `[M+Cl]-` ion) with confidence **A-**.
+- FT0153 (RT = 174.6, `[M+HCOO]-` ion) with confidence **A-**.
+- Reference MS2: `[M-H]-`: FT0153_F15.S0516, FT0153_F16.S0551; high confidence.
+
 
 ### Hypoxanthine
 
@@ -2281,28 +2300,13 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
 
-For completeness, we also perform a neutral loss spectra comparison with HMDB
-and MassBank.
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, hmdb_nl, sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, mbank_nl,
-              sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
 
 #### Summary
 
-- FT0204 (RT = 122.1, `[M-H]-` ion) with confidence level **B**. Spectra
-  F16.S0299 and F15.S0290.
-- FT0540 (RT = 122.8, `[M+HCOO]-` ion) inherits confidence level from FT0204.
+- FT0204 (RT = 122.1, `[M-H]-` ion) with confidence level **B**.
+- FT0540 (RT = 122.8, `[M+HCOO]-` ion) with confidence level **B-**.
+- Reference MS2: `[M-H]-`: FT0204_F15.S0290, FT0204_F16.S0299; high confidence.
 
-From neutral loss comparison we get also matches for spectra from FT0544 but one
-of them matches better with 1-Methyluric acid.
 
 ### L-Kynurenine
 
@@ -2312,10 +2316,6 @@ std <- "L-Kynurenine"
 
 ```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
 ```
-
-Many features have been assigned to this standard based on
-m/z matching. Based on their retention times, these seem however to represent
-ions from different compounds.
 
 We next plot the EIC for the assigned feature and visually inspect these.
 
@@ -2392,8 +2392,10 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-No MS2 spectra match against reference spectra from `r std` but a match
-against D-Pinitol. 
+- Inconclusive.
+- From the signal it seems FT1171 might be the *best* candidate, but the MS2
+  spectra don't match.
+
 
 ### Lactic acid
 
@@ -2490,15 +2492,11 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-We only find very low similarity matches with spectra from FT0025. The EIC of 
-- FT0025 (RT = 41.7, `[M-H]-` ion) with confidence **C**? Spectrum F15.S0109
-  matches reference spectra from `r std` with similarity around 0.41. (only
-  one peak matches).
-- FT0200 (RT = 43.7, `[M+HCOO]-` ion) with confidence **C-**? (same feature
-  group as FT0025).
+- FT0025 (RT = 41.7, `[M-H]-` ion) with confidence **C**.
+- Reference MS2: `[M-H]-`: FT0025_F15.S0109, FT0025_F16.S0106; low confidence.
+- Feature FT0200 is in the same feature group than FT0025, but its EIC looks
+  different and the signal is also very low.
 
-FT0204 was matched to this standard in addition to Hypoxanthine but probably
-represent signal for Hypoxanthine.
 
 ### 1-Methylxanthine
 
@@ -2569,10 +2567,13 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 #### Summary
 
 - FT0396 (RT = 80.1, `[M-H]-` ion) with confidence level **A**.
-  MS2 spectra: F15.S0211 and F16.S0163.
-- FT0822 (RT = 80.2, `[M+HCOO]-` ion) in the same feature group as FT0396
 - FT0397 (RT = 56.4, `[M-H]-` ion) with confidence level **A**.
-- FT0823 (RT = 57.4, `[M+HCOO]-` ion) in the same feature group as FT0396.
+- FT0822 (RT = 80.2, `[M+HCOO]-` ion) with confidence level **A-**.
+- FT0823 (RT = 57.4, `[M+HCOO]-` ion) with confidence level **A-**.
+- We might opt to select one of the two, either 56 or 80 seconds.
+- Reference MS2: FT0397_F15.S0152, FT0397_F16.S0137, FT0397_F16.S0163,
+  FT0396_F15.S0211, FT0396_F16.S0211; high confidence.
+
 
 ### 3-Nitrotyrosine
 
@@ -2654,23 +2655,12 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
 
-For completeness, we also perform a neutral loss spectra comparison with HMDB
-and MassBank.
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, hmdb_nl, sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, mbank_nl,
-              sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
 
 #### Summary
 
-- FT0950 (RT = 173.1, `[M-H]-` ion) with confidence **B**.
+- FT0950 (RT = 173.1, `[M-H]-` ion) with confidence **A**.
+- Reference MS2: `[M-H-]`: FT0950_F15.S0493, FT0950_F16.S0501; high confidence.
+
 
 ### Phosphocreatine
 
@@ -2701,7 +2691,8 @@ plot_spectra(std_ms2)
 
 #### Summary
 
-No MS2 spectra available.
+- FT0814 (RT = 196.1, `[M-H]-` ion) confidence level **D**.
+
 
 ### UDP-glucuronate
 
@@ -2753,7 +2744,7 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
 We obtain similar results from the MassBank comparison. In addition, since
-there are extracted spectra is associated to an ion different from `[M+H]+`
+there are extracted spectra is associated to an ion different from `[M-H]-`
 (`[M+Cl]-`) we perform a neutral loss spectra comparison.
 
 ```{r mix02-water-neg-udp-glucuronate-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
@@ -2802,19 +2793,13 @@ perform_match(std_ms2_nl, mbank_nl,
 
 #### Summary
 
-Strange situation:
-
-- FT4308 (RT = 324.6, `[M-H]-` ion) with confidence **A**? Spectrum F15.S0857
-  (and F16.S0878). No "low" signal is visible in the EIC of this feature.
-- FT4309 (RT = 213, `[M-H]-` ion) with confidence **A**? Spectrum F16.S0597
-  No "low" signal is visible in the EIC of this feature.
-- FT4310 (RT = 194.7, `[M-H]-` ion) with confidence **A**? F16.S0641
-  No "low" signal is visible in the EIC of this feature.
-- FT4311 (RT = 244.3, `[M-H]-` ion) with confidence **A**? F16.S0641
-  No "low" signal is visible in the EIC of this feature.
-- FT4312 (RT = 268.3, `[M-H]-` ion) with confidence **A**? Spectra F15.S0728
-  and F15.S0745. But EIC maybe doesn't look super good.
-
+- FT4308 (RT = 324.6, `[M-H]-` ion) confidence **A**.
+- FT4312 (RT = 268.3, `[M-H]-` ion) confidence **A**.
+- Seems that all other features are somewhat also showing signal from this ion,
+  along the almost complete retention time range. Highest signal is however
+  FT4308.
+- Reference MS2: `[M-H]-`: FT4308_F15.S0857, FT4308_F16.S0878, FT4312_F15.S0728,
+  FT4312_F15.S0745; high confidence.
   
 
 ### Valine
@@ -2854,7 +2839,8 @@ sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
 ```
 
 Both available spectra from FT0099 (F16.S0463 and F15.S0434) match reference
-spectra for `r std`.
+spectra for `r std`, but, with the exception of one, only with their precursor
+peak.
 
 ```{r mix02-water-neg-valine-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
 std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7, ppm = csp@ppm,
@@ -2892,11 +2878,10 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 
 #### Summary
 
-Both available spectra from FT0099 (F16.S0463 and F15.S0434) match reference
-spectra for `r std`.
-- FT0099 (RT= 158.6, `[M-H]-` ion) with confidence level **B**. Spectra 
-  F16.S0463 and F15.S0434.
-- FT0362 (RT= 158.8, `[M+HCOO]-` ion).
+- FT0099 (RT= 158.6, `[M-H]-` ion) with confidence level **B**. 
+- FT0362 (RT= 158.8, `[M+HCOO]-` ion) confidence level **B-**.
+- Reference MS2: `[M-H]-`: FT0099_F16.S0463, FT0099_F15.S0434; high confidence.
+
 
 ## Standards without any matching feature
 

--- a/match-standards-water-mix02.Rmd
+++ b/match-standards-water-mix02.Rmd
@@ -52,27 +52,6 @@ Garcia-Aloy.
 ```{r, standards-table, echo = FALSE, results = "asis"}
 ```
 
-```{r}
-iso <- data.frame(
-    mix = 2,
-    name = "Isobutyryl-L-carnitine",
-    abbreviation = NA,
-    HMDB = "HMDB0000736",
-    formula = "C11H22NO4",
-    POS = NA,
-    NEG = NA,
-    RT = 37,
-    data_set = NA,
-    sample = NA,
-    operator = NA,
-    version = NA,
-    quality_POS = NA,
-    quality_NEG = NA,
-    exactmass = calculateMass("C11H22NO4")
-)
-std_dilution <- rbind(std_dilution, iso)
-```
-
 # Data import
 
 We next load the data and split it according to matrix and polarity.
@@ -426,41 +405,6 @@ perform_match(std_ms2_nl, mbank_nl,
   retention time range.
 - Check with Vinicius: what was the actual compound used? Why was the formula
   adapted?
-
-### Isobutyryl-L-carnitine
-
-
-```{r, echo = FALSE}
-std <- "Isobutyryl-L-carnitine"
-```
-
-```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
-```
-
-Many features have been assigned to this standard based on
-m/z matching. Based on their retention times, these seem however to represent
-ions from different compounds.
-
-We next plot the EIC for the assigned feature and visually inspect these.
-
-```{r, echo = FALSE}
-plot_eics(data, std, feature_table, "WP", std_ms2)
-```
-
-The cleaned MS2 spectra for the features matched to `r std` are shown below
-(peaks with an intensity below 5% of the maximum peak and spectra with less
-than 2 peaks where removed).
-
-```{r mix02-water-pos-isobutyryl-l-carnitine-ms2, echo = FALSE}
-plot_spectra(std_ms2)
-```
-
-
-#### Summary
-
-- The signal for the `[M+H]+` ion for Isobutyryl-L-carnitine (with the formula
-  provided by HMDB!) is much higher than the one for C4 Carnitine. Still, no MS2
-  spectra are available for this feature.
   
 
 ### Fructose

--- a/match-standards-water-mix02.Rmd
+++ b/match-standards-water-mix02.Rmd
@@ -298,9 +298,23 @@ their precursor m/z values is however large.
   **C**.
 - Reference MS2: FT1811 `[M+H+]`: FT1811_F07.S0399 (high confidence),
   FT1811_F08.S0391 (low confidence).
-  
 
-### C4 Carnitine
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT1811_F07.S0399", "FT1811_F08.S0391")]
+ms2$confidence <- c("high", "low")
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
+### C4 Carnitine (Isobutyryl-L-carnitine
+
+The *C4 Carnitine* standard is, according to the order number from Sigma Aldrich
+(51085) in fact Isobutyryl-L-carnitine.
 
 ```{r, echo = FALSE}
 std <- "C4 Carnitine"
@@ -341,9 +355,8 @@ std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
 sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
 ```
 
-In both cases we don't find any match. In addition, since all the extracted
-spectra are associated to ions different from `[M+H]+` we perform a neutral
-loss spectra comparison.
+In both cases we don't find any match. In addition we perform a neutral loss
+spectra comparison.
 
 ```{r mix02-water-pos-c4-carnitine-ms2-hmdb_nl, echo = FALSE, fig.width = 5, fig.height = 5}
 std_hmdb_nl <- hmdb_nl[hmdb_nl$compound_id == hmdb_id]
@@ -360,13 +373,39 @@ sim <- plot_ms2_similarity_heatmap(std_ms2_nl, std_mbank_nl, csp_nl)
 For the HMDB comparison we don't find matches while for the MassBank one
 the neutral loss spectra cannot be computed. 
 
+The chemical formula reported from Sigma Aldrich would match the chemical
+formula of Butyrylcarnitine (C4 Carnitine). Thus we match below the MS2 spectra
+associated with the features to the reference spectra for Butyrylcarnitine
+(HMDB0002013).
+
+```{r mix02-water-pos-butyrylcarnitine-ms2-hmdb, echo = FALSE, fig.width = 5, fig.height = 5}
+hmdb_id <- "HMDB0002013"
+std_hmdb <- Spectra(cdb, filter = ~ compound_id == hmdb_id)
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_hmdb, csp)
+```
+
+We get now matches with quite high similarity.
+
+```{r mix02-water-pos-ascorbic-butyrylcarnitine-mirror-hmdb, echo = TRUE, fig.cap = "Mirror plots"}
+std_ms2_sel <- plot_select_ms2(std_ms2, std_hmdb, 0.7,
+                               ppm = csp@ppm, tolerance = csp@tolerance)
+```
+
+The spectra are very similar, thus, we either measure here butyrylcarnitine or
+the reference spectra were assigned to the wrong compound. We repeat the same
+match against MassBank.
+
+```{r mix02-water-pos-butyrylcarnitine-ms2-mbank, echo = FALSE, fig.width = 5, fig.height = 5}
+std_mbank <- get_mbank(mbank, inchikey = unique(std_hmdb$inchikey))
+sim <- plot_ms2_similarity_heatmap(std_ms2, std_mbank, csp)
+```
+
 In addition we match (**all**) the MS2 spectra for the matched features against
 all spectra from HMDB or MassBank identifying reference spectra with a
 similarity larger than 0.7. The results (if any spectra matched) are shown in
 the two following tables.
 
 ```{r, echo = FALSE, message = FALSE, results = "asis"}
-std_ms2_sel <- Spectra()
 perform_match(std_ms2, hmdb, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
@@ -380,32 +419,48 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
               name = "target_name", param = csp)
 ```
 
-For completeness, we also perform a neutral loss spectra comparison with HMDB
-and MassBank.
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, hmdb_nl, sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
-
-```{r, echo = FALSE, message = FALSE, results = "asis", eval = ALL_NL_MATCH}
-perform_match(std_ms2_nl, mbank_nl,
-              sv = c("rtime", "target_name", "score"),
-              name = "target_name", param = csp_nl)
-```
-
 
 #### Summary
 
+- FT2684 (RT = 37, `[M+H]+` ion) with confidence level **A** (to
+  butyrylcarnitine).
+- FT2398 (RT = 24, `[M+H-NH3]+` ion) with confidence level **A-**.
+- Reference MS2: `[M+H]+`: FT2684_F07.S0167, FT2682_F07.S0369, FT2682_F07.S0425,
+  FT2685_F07.S0598, FT2682_F08.S0357; high confidence.
 - MS2 spectra for features FT2682 (RT=123), FT2685 (RT=167), FT2683 (RT=143),
   FT2684 (RT=37) and FT2686 (RT=44) match Butyrylcarnitine (C11H21NO4) but not
   the actual carnitine (C11H22NO4), i.e. with one H more. Note also that the
   formula used for this compound matches the one of butyrylcarnitine!
 - What is however very strange is that EICs are present along the whole
   retention time range.
-- Check with Vinicius: what was the actual compound used? Why was the formula
-  adapted?
+- The order number for *C4 Carnitine* at Sigma Aldrich is 51085, which is
+  however Isobutyryl-L-carnitine. The chemical formula listed with Sigma Aldrich
+  is however C11H21NO4. According to HMDB, ChEBI and PubChem this is however the
+  chemical formula for Butyrylcarnitine while the one for Isobutyryl-L-carnitine
+  is C11H22NO4. In a previous analysis also the latter formula for
+  Isobutyryl-L-carnitine was used and features (with similar EIC) with much
+  higher intensity were found - for these no MS2 spectra were however measured.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT2398"),
+                  confidence_level = c("A-"))
+fts$note <- paste0("Ambiguous: standard is isobutyryl-L-carnitine (Sigma ",
+                   "Aldrich 51085), but matches butyrylcarnitine.")
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT2684_F07.S0167", "FT2682_F07.S0369", "FT2682_F07.S0425",
+                 "FT2685_F07.S0598", "FT2682_F08.S0357")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Fructose
 
@@ -587,6 +642,18 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
   F08.S0584 matches only `r std` with a low similarity.
 - Reference MS2: `[M+H]+`: FT0102_F08.S0584; low confidence.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0102_F08.S0584")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 ### cGMP
 
 ```{r, echo = FALSE}
@@ -684,6 +751,19 @@ the same?).
 - Reference MS2: `[M+H]+`: FT4591_F07.S0777; high confidence, FT4591_F07.S0735,
   FT4591_F08.S0747: low confidence. `[M+Na]+`: FT4903_F08.S0748?
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT4591_F07.S0777", "FT4591_F07.S0735", "FT4591_F08.S0747",
+                 "FT4903_F08.S0748")]
+ms2$confidence <- c("high", "low", "low", "low")
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 
 ### Histidine
 
@@ -799,6 +879,24 @@ perform_match(std_ms2_nl, mbank_nl,
 - Feature FT1376, which MS2 also match reference spectra for `r std` matches
   also phenylpyridine and is thus most likely **not** `r std`.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT1368", "FT1832", "FT2093"),
+                  confidence_level = c("A", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT1368_F07.S0668", "FT1368_F08.S0658", "FT1368_F08.S0740",
+                 "FT1369_F07.S0730", "FT2093_F07.S0663")]
+ms2$confidence <- c("high", "high", "high", "high", "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
   
 ### Hydroxyproline
 
@@ -909,6 +1007,18 @@ perform_match(std_ms2_nl, mbank_nl,
 - It is unclear what to do with FT0789 (RT = 74.4, `[M+H]+`): which MS2 spectra
   also matches the compound of interest, but with a lower score?
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0790_F08.S0599", "FT0790_F07.S0659", "FT0790_F08.S0644",
+                 "FT0790_F07.S0613")]
+ms2$confidence <- c("high", "high", "high", "low")
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Hypoxanthine
 
@@ -1013,11 +1123,24 @@ perform_match(std_ms2_nl, mbank_nl,
 #### Summary
 
 - FT0955 (RT = 126.1, ion `[M+H]+`): confidence level **A**.
-- FT0611 (RT = 126.3, ion `[M+H-H2O]+`): confidence level **C**.
-- FT1777 (RT = 123.9, ion `[M+K]+`): confidence level **C**.
+- FT0611 (RT = 126.3, ion `[M+H-H2O]+`): confidence level **A-**.
+- FT1777 (RT = 123.9, ion `[M+K]+`): confidence level **A-**.
 - Reference MS2: `[M+H]+`: FT0955_F07.S0376, FT0955_F08.S0374; high
   confidence. `[M+H-H2O]+`: FT0611_F07.S0374, FT0611_F08.S0372; low confidence.
   `[M+K]+`: FT1777_F07.S0378, FT1777_F08.S0381; low confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0955_F07.S0376", "FT0955_F08.S0374", "FT0611_F07.S0374",
+                 "FT0611_F08.S0372", "FT1777_F07.S0378", "FT1777_F08.S0381")]
+ms2$confidence <- c("high", "high", "low", "low", "low", "low")
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### L-Kynurenine
 
@@ -1135,6 +1258,25 @@ perform_match(std_ms2_nl, mbank_nl,
 - Feature FT2301 (RT = 164, `[M+H]+` ion) will be ignored as the retention time
   is about 10 seconds delayed and its signal is much lower than for the
   first. So maybe that is just some *left over* from the column (?).
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT2299", "FT2069", "FT2654", "FT3226"),
+                  confidence_level = c("A", "A-", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT2299_F07.S0477", "FT2299_F08.S0479", "FT2069_F07.S0476",
+                 "FT2069_F08.S0478", "FT2654_F07.S0479", "FT2654_F08.S0481",
+                 "FT3226_F07.S0480", "FT3226_F08.S0482")]
+ms2$confidence <- c("high", "high", "high", "high", "low", "low", "low", "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
 
 
 ### Lactic acid
@@ -1275,7 +1417,27 @@ Inheriting confidence level from FT1642 for being in the same feature group:
   FT2024_F08.S0286; low confidence.
 - FT1646: this EIC is partially overlapping with FT1642 and will thus be ignores
   (but its MS2 spectra will be added).
-  
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT1642", "FT2024", "FT2249", "FT3108"),
+                  confidence_level = c("A", "A-", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT1642_F07.S0223", "FT1642_F07.S0271", "FT1642_F08.S0270",
+                 "FT1646_F07.S0185", "FT1646_F08.S0190", "FT1646_F08.S0227",
+                 "FT2024_F07.S0294", "FT2024_F08.S0214", "FT2024_F08.S0261",
+                 "FT2024_F08.S0286")]
+ms2$confidence <- c(rep("high", 6), rep("low", 4))
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### 3-Nitrotyrosine
 
@@ -1379,7 +1541,24 @@ perform_match(std_ms2_nl, mbank_nl,
 - FT3454 (RT=161.5, `[M+2Na-H]+` ion) with confidence level **A-**.
 - Reference MS2: `[M+H]+`: FT2571_F07.S0574; high confidence. `[M+2Na-H]+`:
   FT3454_F08.S0505; low confidence.
-  
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT2571", "FT3454"),
+                  confidence_level = c("A", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT2571_F07.S0574", "FT3454_F08.S0505")]
+ms2$confidence <- c("high", "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Phosphocreatine
 
@@ -1484,6 +1663,23 @@ perform_match(std_ms2_nl, mbank_nl,
 - FT2352/FT2353 (RT = 196.3, `[M+H]+` ion) with confidence level **C**.
 - Reference MS2: `[M+H]+`: FT2352_F07.S0726; low confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT2352"),
+                  confidence_level = c("C"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT2352_F07.S0726")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### UDP-glucuronate
 
@@ -1668,6 +1864,24 @@ Also D-Valine is different from L-Valine?
 - Reference MS2: `[M+H]+`: FT0594_F07.S0533; high confidence. FT0594_F08.S0494;
   low confidence.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0594", "FT1553"),
+                  confidence_level = c("A", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0594_F07.S0533", "FT0594_F08.S0494")]
+ms2$confidence <- c("high", "low")
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 
 # Water, negative polarity
 
@@ -1802,9 +2016,27 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - Feature FT0476 (RT = 36.75, `[M-H]-` ion) matches also with its MS2 spectra to
   the current compound, but signal is much lower than for the feature with
   higher retention time.
-  
 
-### C4 Carnitine
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0475"),
+                  confidence_level = c("A"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0475_F15.S0311", "FT0475_F16.S0290", "FT0475_F16.S0326")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
+
+### C4 Carnitine (Isobutyryl-L-carnitine)
 
 ```{r, echo = FALSE}
 std <- "C4 Carnitine"
@@ -1982,6 +2214,23 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - FT0013 (RT = 170.6, `[M-H]-` ion) with confidence level **A**.
 - Reference MS2: `[M-H-]`: FT0013_F16.S0546; high confidence.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0013"),
+                  confidence_level = c("A"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0013_F16.S0546")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### cGMP
 
@@ -2058,6 +2307,23 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - Reference MS2: `[M-H]-`: FT2364_F15.S0611, FT2364_F15.S0654, FT2364_F16.S0644;
   high confidence.
   
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT2364", "FT2846"),
+                  confidence_level = c("A", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT2364_F15.S0611", "FT2364_F15.S0654", "FT2364_F16.S0644")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### Histidine
 
@@ -2137,6 +2403,18 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - While also for the other features MS2 spectra match the reference they will
   not be considered (much lower signal).
 - Reference MS2: `[M-H]-`: FT0309_F15.S0548, FT0309_F16.S0574; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0309_F15.S0548", "FT0309_F16.S0574")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 
 ### Hydroxyproline
@@ -2219,6 +2497,23 @@ different (?) from `r std`.
 - FT0404 (RT = 174.7, `[M+Cl]-` ion) with confidence **A-**.
 - FT0153 (RT = 174.6, `[M+HCOO]-` ion) with confidence **A-**.
 - Reference MS2: `[M-H]-`: FT0153_F15.S0516, FT0153_F16.S0551; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0153", "FT0404", "FT0153"),
+                  confidence_level = c("A", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0153_F15.S0516", "FT0153_F16.S0551")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
 
 
 ### Hypoxanthine
@@ -2309,6 +2604,24 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - FT0204 (RT = 122.1, `[M-H]-` ion) with confidence level **B**.
 - FT0540 (RT = 122.8, `[M+HCOO]-` ion) with confidence level **B-**.
 - Reference MS2: `[M-H]-`: FT0204_F15.S0290, FT0204_F16.S0299; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0204", "FT0540"),
+                  confidence_level = c("B", "B-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0204_F15.S0290", "FT0204_F16.S0299")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 
 ### L-Kynurenine
@@ -2500,6 +2813,23 @@ perform_match(std_ms2_nl, mbank_nl,
 - Feature FT0200 is in the same feature group than FT0025, but its EIC looks
   different and the signal is also very low.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0025"),
+                  confidence_level = c("C"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0025_F15.S0109", "FT0025_F16.S0106")]
+ms2$confidence <- "low"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 ### 1-Methylxanthine
 
@@ -2576,6 +2906,25 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - We might opt to select one of the two, either 56 or 80 seconds.
 - Reference MS2: FT0397_F15.S0152, FT0397_F16.S0137, FT0397_F16.S0163,
   FT0396_F15.S0211, FT0396_F16.S0211; high confidence.
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0396", "FT0397", "FT0822", "FT0823"),
+                  confidence_level = c("A", "A", "A-", "A-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0397_F15.S0152", "FT0397_F16.S0137", "FT0397_F16.S0163",
+                 "FT0396_F15.S0211", "FT0396_F16.S0211")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
 
 
 ### 3-Nitrotyrosine
@@ -2696,6 +3045,18 @@ plot_spectra(std_ms2)
 
 - FT0814 (RT = 196.1, `[M-H]-` ion) confidence level **D**.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0814"),
+                  confidence_level = c("D"))
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+
 
 ### UDP-glucuronate
 
@@ -2803,7 +3164,26 @@ perform_match(std_ms2_nl, mbank_nl,
   FT4308.
 - Reference MS2: `[M-H]-`: FT4308_F15.S0857, FT4308_F16.S0878, FT4312_F15.S0728,
   FT4312_F15.S0745; high confidence.
-  
+
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT4308", "FT4312"),
+                  confidence_level = c("A", "A"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT4308_F15.S0857", "FT4308_F16.S0878", "FT4312_F15.S0728",
+                 "FT4312_F15.S0745")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 
 ### Valine
 
@@ -2885,8 +3265,33 @@ perform_match(std_ms2, mbank, sv = c("rtime", "target_name", "score"),
 - FT0362 (RT= 158.8, `[M+HCOO]-` ion) confidence level **B-**.
 - Reference MS2: `[M-H]-`: FT0099_F16.S0463, FT0099_F15.S0434; high confidence.
 
+The associated ion and MS2 spectra are added to the database.
+
+```{r, echo = FALSE}
+## Define the feature (ion) and MS2 spectra to insert
+fts <- data.frame(feature_id = c("FT0099", "FT0362"),
+                  confidence_level = c("B", "B-"))
+## Get MS2 spectra:
+ms2 <- std_ms2[c("FT0099_F16.S0463", "FT0099_F15.S0434")]
+ms2$confidence <- "high"
+```
+
+```{r, add-ions, echo = FALSE}
+```
+
+```{r, add-ms2-spectra, echo = FALSE}
+```
+
+
 
 ## Standards without any matching feature
+
+# Summary on the ion database
+
+Summarizing the content that was added to the `IonDb`.
+
+```{r, iondb-summary, echo = FALSE, results = "asis"}
+```
 
 # Session information
 

--- a/match-standards-water-mix02.Rmd
+++ b/match-standards-water-mix02.Rmd
@@ -25,7 +25,7 @@ FEATURE_MS2_TOLERANCE <- 0.05
 ```{r, general-settings, echo = FALSE, message = FALSE}
 ```
 
-**Current version: 0.9.0, 2022-03-09.**
+**Current version: 0.10.0, 2022-05-30.**
 
 # Introduction
 
@@ -52,6 +52,27 @@ Garcia-Aloy.
 ```{r, standards-table, echo = FALSE, results = "asis"}
 ```
 
+```{r}
+iso <- data.frame(
+    mix = 2,
+    name = "Isobutyryl-L-carnitine",
+    abbreviation = NA,
+    HMDB = "HMDB0000736",
+    formula = "C11H22NO4",
+    POS = NA,
+    NEG = NA,
+    RT = 37,
+    data_set = NA,
+    sample = NA,
+    operator = NA,
+    version = NA,
+    quality_POS = NA,
+    quality_NEG = NA,
+    exactmass = calculateMass("C11H22NO4")
+)
+std_dilution <- rbind(std_dilution, iso)
+```
+
 # Data import
 
 We next load the data and split it according to matrix and polarity.
@@ -67,6 +88,9 @@ ions (respectively `[M-H]-` ions for negative polarity) and add the m/z for
 these adducts as *precursor m/z*.
 
 ```{r, load-reference-databases, message = FALSE}
+```
+
+```{r, setup-ion-db, message = FALSE, echo = FALSE}
 ```
 
 # Initial evaluation of available MS2 data
@@ -403,6 +427,41 @@ perform_match(std_ms2_nl, mbank_nl,
 - Check with Vinicius: what was the actual compound used? Why was the formula
   adapted?
 
+### Isobutyryl-L-carnitine
+
+
+```{r, echo = FALSE}
+std <- "Isobutyryl-L-carnitine"
+```
+
+```{r, table-feature-matches, results = "asis", echo = FALSE, message = FALSE}
+```
+
+Many features have been assigned to this standard based on
+m/z matching. Based on their retention times, these seem however to represent
+ions from different compounds.
+
+We next plot the EIC for the assigned feature and visually inspect these.
+
+```{r, echo = FALSE}
+plot_eics(data, std, feature_table, "WP", std_ms2)
+```
+
+The cleaned MS2 spectra for the features matched to `r std` are shown below
+(peaks with an intensity below 5% of the maximum peak and spectra with less
+than 2 peaks where removed).
+
+```{r mix02-water-pos-isobutyryl-l-carnitine-ms2, echo = FALSE}
+plot_spectra(std_ms2)
+```
+
+
+#### Summary
+
+- The signal for the `[M+H]+` ion for Isobutyryl-L-carnitine (with the formula
+  provided by HMDB!) is much higher than the one for C4 Carnitine. Still, no MS2
+  spectra are available for this feature.
+  
 
 ### Fructose
 


### PR DESCRIPTION
- Cross-check and finalize assignment of features and MS2 spectra to standards.
- *Solve* (?) C4 carnitine discrepancy (from the MS2 data it looks like the standard could be butyrylcarnitine, not isobutyryl-L-carnitine).
- Add ions and MS2 spectra to the ion database.